### PR TITLE
Filter by custom date (45)

### DIFF
--- a/src/components/filters/DateRangeFilter.tsx
+++ b/src/components/filters/DateRangeFilter.tsx
@@ -20,10 +20,32 @@ const presets: { value: RangePreset; label: string }[] = [
   { value: "24h", label: "Last 24 Hours" },
   { value: "7d", label: "Last 7 Days" },
   { value: "30d", label: "Last 30 Days" },
+  { value: "custom", label: "Custom Range" },
 ];
 
+function toDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+const dateInputClass =
+  "h-8 w-full rounded border border-border bg-card px-2 text-sm text-foreground outline-none transition-colors hover:border-muted-foreground focus:ring-1 focus:ring-ring [&::-webkit-calendar-picker-indicator]:invert";
+
 function DateRangeFilter() {
-  const { updateFilters, rangePreset } = useFilters();
+  const { updateFilters, rangePreset, startDate, endDate } = useFilters();
+
+  const handlePresetChange = (value: string) => {
+    if (value === "custom") {
+      const now = new Date();
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      updateFilters({
+        rangePreset: "custom",
+        startDate: toDateString(weekAgo),
+        endDate: toDateString(now),
+      });
+    } else {
+      updateFilters({ rangePreset: value as RangePreset, startDate: "", endDate: "" });
+    }
+  };
 
   return (
     <div className={filterFieldClass}>
@@ -31,15 +53,10 @@ function DateRangeFilter() {
         <CalendarIcon className="h-3 w-3" />
         Date Range
       </Label>
-      <Select
-        value={rangePreset}
-        onValueChange={(value) =>
-          updateFilters({ rangePreset: (value as RangePreset) ?? undefined })
-        }
-      >
+      <Select value={rangePreset} onValueChange={(v) => v && handlePresetChange(v)}>
         <SelectTrigger id="filter-date-range" className={filterSelectClass}>
           <SelectValue>
-            {presets.find((preset) => preset.value === rangePreset)?.label ?? "Custom"}
+            {presets.find((p) => p.value === rangePreset)?.label ?? "Custom Range"}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
@@ -50,6 +67,26 @@ function DateRangeFilter() {
           ))}
         </SelectContent>
       </Select>
+
+      {rangePreset === "custom" && (
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            aria-label="Start date"
+            className={dateInputClass}
+            value={startDate ? startDate.slice(0, 10) : ""}
+            onChange={(e) => updateFilters({ startDate: e.target.value })}
+          />
+          <span className="shrink-0 text-xs text-muted-foreground">to</span>
+          <input
+            type="date"
+            aria-label="End date"
+            className={dateInputClass}
+            value={endDate ? endDate.slice(0, 10) : ""}
+            onChange={(e) => updateFilters({ endDate: e.target.value })}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #45 

### What was done
Adds a "Custom Range" option to the date range dropdown. When selected, two native date inputs appear allowing the user to pick an some sort of "arbitrary" start and end date. The selected dates are persisted in URL search params via the existing useFilters hook.

### Note: 
The date picker popup uses the browser's native <input type="date"> widget. I tried react-day-picker for a styled calendar but ran into issues with multi-month navigation resetting state and cramped layout with the dropdown caption. Reverted to native inputs for now. Itworks reliably but the popup inherits browser/OS styling. 

Could be revisited later with a custom-built date picker component if a consistent dark-theme calendar is desired.