### PR TITLE
46 Collapsible filter header

### DIFF
--- a/src/lib/hooks/useScrollDirection.ts
+++ b/src/lib/hooks/useScrollDirection.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+
+type ScrollDirection = "up" | "down" | null;
+
+const LOCK_MS = 400;
+
+function useScrollDirection() {
+  const [direction, setDirection] = useState<ScrollDirection>(null);
+  const [scrolled, setScrolled] = useState(false);
+  const lastY = useRef(0);
+  const lockedUntil = useRef(0);
+
+  useEffect(() => {
+    const el = document.querySelector("main")?.parentElement;
+    if (!el) {
+      return;
+    }
+
+    let ticking = false;
+
+    const onScroll = () => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+
+      requestAnimationFrame(() => {
+        const y = el.scrollTop;
+        const now = performance.now();
+
+        if (now > lockedUntil.current) {
+          setScrolled((prev) => {
+            const next = y > 10;
+            if (next !== prev) {
+              lockedUntil.current = now + LOCK_MS;
+            }
+            return next;
+          });
+        }
+
+        const diff = y - lastY.current;
+        if (Math.abs(diff) > 5) {
+          setDirection(diff > 0 ? "down" : "up");
+          lastY.current = y;
+        }
+
+        ticking = false;
+      });
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return { direction, scrolled };
+}
+
+export { useScrollDirection };

--- a/src/routes/deployment/$deploymentId/_filterLayout.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout.tsx
@@ -9,6 +9,7 @@ import { buttonVariants } from "@/components/ui/button-variants";
 import { Separator } from "@/components/ui/Separator";
 import { filtersDefault, filtersSchema } from "@/lib/filters";
 import { FilterProvider } from "@/lib/filters/FilterContext";
+import { useScrollDirection } from "@/lib/hooks/useScrollDirection";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/deployment/$deploymentId/_filterLayout")({
@@ -19,31 +20,45 @@ export const Route = createFileRoute("/deployment/$deploymentId/_filterLayout")(
   component: LayoutComponent,
 });
 
+function CollapsibleNav({ deploymentId }: { deploymentId: string }) {
+  return (
+    <div className="overflow-hidden">
+      <div className="flex items-center gap-3 px-6 py-3">
+        <Link
+          to="/"
+          className={cn(
+            buttonVariants({ variant: "ghost", size: "sm" }),
+            "gap-1 text-muted-foreground",
+          )}
+        >
+          <ChevronLeftIcon />
+          Deployments
+        </Link>
+        <Separator orientation="vertical" />
+        <h1 className="font-semibold">{deploymentId}</h1>
+      </div>
+      <Separator />
+      <DeploymentSelector deploymentId={deploymentId} />
+    </div>
+  );
+}
+
 function LayoutComponent() {
   const { deploymentId } = Route.useParams();
+  const { scrolled } = useScrollDirection();
 
   return (
     <FilterProvider>
-      {/* top-16.25 is a hacky fix but I don't know how else to do it - needs to be updated if header changes size */}
       <div className="sticky top-16.25 z-10 flex flex-col bg-background/90 backdrop-blur-lg">
-        {/* Not in figma, maybe remove remove? (header + filters take a lot of space) */}
-        <div className="flex items-center gap-3 px-6 py-3">
-          <Link
-            to="/"
-            className={cn(
-              buttonVariants({ variant: "ghost", size: "sm" }),
-              "gap-1 text-muted-foreground",
-            )}
-          >
-            <ChevronLeftIcon />
-            Deployments
-          </Link>
-          <Separator orientation="vertical" />
-          <h1 className="font-semibold">{deploymentId}</h1>
+        <div
+          className={cn(
+            "grid transition-[grid-template-rows,opacity] duration-300 ease-in-out",
+            scrolled ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100",
+          )}
+        >
+          <CollapsibleNav deploymentId={deploymentId} />
         </div>
 
-        <Separator />
-        <DeploymentSelector deploymentId={deploymentId} />
         <Separator />
         <FiltersRow />
         <Separator />


### PR DESCRIPTION
Closes #46 

Collapses the back button and deployment selector tabs when scrolling down, keeping the filter row and tab selector always visible. Expands again when scrolling back to the top. 

Uses a cooldown lock to prevent oscillation from scroll position shifts. May be bad practice, but if anyone else has any input to this, please try out a different approach. 