### PR TITLE
42 activity heatmap

### DIFF
--- a/src/components/charts/ActivityHeatmap.tsx
+++ b/src/components/charts/ActivityHeatmap.tsx
@@ -1,58 +1,87 @@
-import { Droplet, Thermometer, Wind } from "lucide-react";
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Spinner } from "@/components/ui/Spinner";
 import type { HeatmapCell, HeatmapGrid } from "@/lib/heatmapAggregation";
 
+import { cellColor, findDefaultCell, getModeCopy } from "./activityHeatmapColors";
+import { CellTooltip, HeatmapHeader } from "./activityHeatmapParts";
+
 interface ActivityHeatmapProps {
   grid: HeatmapGrid;
-  peakIntensity: number;
-  rangeLabel: string;
   taxonomyLabel: string;
   isLoading?: boolean;
 }
 
-const INTENSITY_STEPS = [0, 0.15, 0.35, 0.6, 1] as const;
-
-function cellColor(count: number, max: number): string {
-  if (max === 0 || count === 0) {
-    return "var(--color-card)";
-  }
-  const ratio = count / max;
-  let step = 0;
-  for (let i = 1; i < INTENSITY_STEPS.length; i++) {
-    if (ratio > INTENSITY_STEPS[i - 1]) {
-      step = i;
-    }
-  }
-  const opacity = 0.15 + step * 0.2;
-  return `color-mix(in oklch, var(--color-chart-2) ${Math.round(opacity * 100)}%, var(--color-card))`;
-}
-
-function ActivityHeatmap({
-  grid,
-  peakIntensity,
-  rangeLabel,
-  taxonomyLabel,
-  isLoading,
-}: ActivityHeatmapProps) {
-  const [hovered, setHovered] = useState<HeatmapCell | null>(null);
+function ActivityHeatmap({ grid, taxonomyLabel, isLoading }: ActivityHeatmapProps) {
+  const [activeCell, setActiveCell] = useState<HeatmapCell | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0, flipped: false });
+  const [isPointerInside, setIsPointerInside] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
-  const tooltipRef = useRef<HTMLDivElement>(null);
 
-  const handleMouseEnter = useCallback((cell: HeatmapCell, e: React.MouseEvent) => {
-    setHovered(cell);
-    if (gridRef.current) {
-      const gridRect = gridRef.current.getBoundingClientRect();
-      const cellRect = e.currentTarget.getBoundingClientRect();
-      const centerX = cellRect.left + cellRect.width / 2 - gridRect.left;
-      const cellTop = cellRect.top - gridRect.top;
-      const flipped = cellTop < 160;
-      const y = flipped ? cellRect.bottom - gridRect.top + 8 : cellTop - 8;
-      setTooltipPos({ x: centerX, y, flipped });
+  const setTooltipForCell = useCallback((cell: HeatmapCell, target?: HTMLElement | null) => {
+    if (!gridRef.current) {
+      return;
     }
+
+    const element =
+      target ??
+      gridRef.current.querySelector<HTMLElement>(`[data-heatmap-cell="${cell.row}-${cell.col}"]`);
+
+    if (!element) {
+      return;
+    }
+
+    const gridRect = gridRef.current.getBoundingClientRect();
+    const cellRect = element.getBoundingClientRect();
+    const centerX = cellRect.left + cellRect.width / 2 - gridRect.left;
+    const cellTop = cellRect.top - gridRect.top;
+    const flipped = cellTop < 160;
+    const y = flipped ? cellRect.bottom - gridRect.top + 8 : cellTop - 8;
+
+    setTooltipPos({ x: centerX, y, flipped });
   }, []);
+
+  const activateCell = useCallback(
+    (cell: HeatmapCell, target?: HTMLElement | null) => {
+      setActiveCell(cell);
+      setTooltipForCell(cell, target);
+    },
+    [setTooltipForCell],
+  );
+
+  useEffect(() => {
+    if (grid.cells.length === 0) {
+      setActiveCell(null);
+      return;
+    }
+
+    const nextCell = findDefaultCell(grid.cells);
+    if (!nextCell) {
+      setActiveCell(null);
+      return;
+    }
+
+    setActiveCell(nextCell);
+
+    const frame = window.requestAnimationFrame(() => {
+      setTooltipForCell(nextCell);
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [grid.cells, setTooltipForCell]);
+
+  useEffect(() => {
+    if (!activeCell) {
+      return;
+    }
+
+    const handleResize = () => {
+      setTooltipForCell(activeCell);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [activeCell, setTooltipForCell]);
 
   if (isLoading) {
     return (
@@ -71,17 +100,26 @@ function ActivityHeatmap({
   }
 
   const cols = grid.colLabels.length;
+  const modeCopy = getModeCopy(grid.mode);
 
   return (
     <div className="flex flex-col gap-4 rounded border border-border bg-card p-6">
-      <HeatmapHeader
-        peakIntensity={peakIntensity}
-        rangeLabel={rangeLabel}
-        taxonomyLabel={taxonomyLabel}
-        maxCount={grid.maxCount}
-      />
+      <HeatmapHeader mode={grid.mode} taxonomyLabel={taxonomyLabel} maxCount={grid.maxCount} />
 
-      <div className="relative" ref={gridRef}>
+      <div
+        className="relative"
+        ref={gridRef}
+        onMouseEnter={() => setIsPointerInside(true)}
+        onMouseLeave={() => {
+          setIsPointerInside(false);
+          setActiveCell(null);
+        }}
+      >
+        <div className="mb-3 flex items-center justify-between gap-4 text-[11px] text-muted-foreground">
+          <span>{modeCopy.description}</span>
+          <span>{modeCopy.structureHint}</span>
+        </div>
+
         <div className="flex gap-1">
           <div className="flex flex-col justify-end gap-1 pt-6 pr-2">
             {grid.rowLabels.map((label) => (
@@ -116,12 +154,15 @@ function ActivityHeatmap({
                 style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
               >
                 {row.map((cell) => (
-                  <div
+                  <button
                     key={`${cell.row}-${cell.col}`}
-                    className="h-7 rounded-sm border border-white/[0.06] transition-[outline] duration-100 hover:outline hover:outline-2 hover:outline-foreground/40"
+                    type="button"
+                    data-heatmap-cell={`${cell.row}-${cell.col}`}
+                    className="h-7 appearance-none rounded-sm border border-white/[0.06] bg-transparent p-0 outline-none focus-visible:ring-0 focus-visible:outline-none"
                     style={{ backgroundColor: cellColor(cell.count, grid.maxCount) }}
-                    onMouseEnter={(e) => handleMouseEnter(cell, e)}
-                    onMouseLeave={() => setHovered(null)}
+                    aria-label={`${cell.label}: ${cell.count} detections`}
+                    onMouseEnter={(e) => activateCell(cell, e.currentTarget)}
+                    onFocus={(e) => activateCell(cell, e.currentTarget)}
                   />
                 ))}
               </div>
@@ -129,10 +170,9 @@ function ActivityHeatmap({
           </div>
         </div>
 
-        {hovered && (
+        {activeCell && isPointerInside && (
           <CellTooltip
-            ref={tooltipRef}
-            cell={hovered}
+            cell={activeCell}
             x={tooltipPos.x}
             y={tooltipPos.y}
             flipped={tooltipPos.flipped}
@@ -142,119 +182,5 @@ function ActivityHeatmap({
     </div>
   );
 }
-
-function HeatmapHeader({
-  peakIntensity,
-  rangeLabel,
-  taxonomyLabel,
-  maxCount,
-}: {
-  peakIntensity: number;
-  rangeLabel: string;
-  taxonomyLabel: string;
-  maxCount: number;
-}) {
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-start justify-between">
-        <div>
-          <h4 className="font-bold tracking-tight uppercase">Detection Activity Heatmap</h4>
-          <p className="text-[11px] text-muted-foreground">
-            Activity patterns by {rangeLabel === "day-hour" ? "day and hour" : "week and day"}{" "}
-            (hover for details)
-          </p>
-        </div>
-        <div className="text-right text-[11px] text-muted-foreground">
-          <span>
-            Temporal Resolution:{" "}
-            <strong className="text-foreground">{rangeLabel.toUpperCase()}</strong>
-          </span>
-          <span className="ml-4">
-            Level: <strong className="text-foreground">{taxonomyLabel.toUpperCase()}</strong>
-          </span>
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className="text-[11px] text-muted-foreground">Activity:</span>
-          {[0, 0.25, 0.5, 0.75, 1].map((ratio) => (
-            <div
-              key={ratio}
-              className="h-4 w-6 rounded-sm"
-              style={{
-                backgroundColor:
-                  ratio === 0
-                    ? "var(--color-card)"
-                    : `color-mix(in oklch, var(--color-chart-2) ${Math.round((0.15 + ratio * 0.8) * 100)}%, var(--color-card))`,
-                outline: "1px solid rgba(255,255,255,0.06)",
-              }}
-            />
-          ))}
-          <span className="text-[10px] text-muted-foreground">Low</span>
-          <span className="text-[10px] text-muted-foreground">High</span>
-        </div>
-        <span className="text-[11px] text-muted-foreground">
-          Peak Intensity: <strong className="text-foreground">{peakIntensity}</strong> detections
-          {maxCount > 0 ? "/cell" : ""}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-const CellTooltip = React.forwardRef<
-  HTMLDivElement,
-  { cell: HeatmapCell; x: number; y: number; flipped: boolean }
->(function CellTooltipInner({ cell, x, y, flipped }, ref) {
-  const arrowBase = "absolute left-1/2 -translate-x-1/2 border-[6px] border-transparent";
-
-  return (
-    <div
-      ref={ref}
-      className="pointer-events-none absolute z-50 min-w-44 -translate-x-1/2 rounded-md border border-border bg-card px-3 py-2 shadow-lg"
-      style={{
-        left: x,
-        ...(flipped ? { top: y } : { bottom: `calc(100% - ${y}px)` }),
-      }}
-    >
-      <p className="text-[11px] font-medium text-muted-foreground uppercase">{cell.label}</p>
-      <p className="mt-0.5 text-lg font-semibold">
-        {cell.count} <span className="text-xs font-normal text-muted-foreground">detections</span>
-      </p>
-      <div className="mt-1.5 flex flex-col gap-1 border-t border-border pt-1.5">
-        <div className="flex items-center justify-between gap-4 text-xs">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <Thermometer className="h-3 w-3" /> Temp
-          </span>
-          <span className="font-medium">
-            {cell.temp !== undefined ? `${cell.temp}\u00B0C` : "--"}
-          </span>
-        </div>
-        <div className="flex items-center justify-between gap-4 text-xs">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <Droplet className="h-3 w-3" /> Humidity
-          </span>
-          <span className="font-medium">
-            {cell.humidity !== undefined ? `${cell.humidity}%` : "--"}
-          </span>
-        </div>
-        <div className="flex items-center justify-between gap-4 text-xs">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <Wind className="h-3 w-3" /> AQI
-          </span>
-          <span className="font-medium">{cell.aqi !== undefined ? cell.aqi : "--"}</span>
-        </div>
-      </div>
-      {/* Arrow */}
-      <span
-        className={`${arrowBase} ${flipped ? "-top-3 border-b-border" : "-bottom-3 border-t-border"}`}
-      />
-      <span
-        className={`${arrowBase} ${flipped ? "-top-[11px] border-b-card" : "-bottom-[11px] border-t-card"}`}
-      />
-    </div>
-  );
-});
 
 export { ActivityHeatmap };

--- a/src/components/charts/ActivityHeatmap.tsx
+++ b/src/components/charts/ActivityHeatmap.tsx
@@ -1,0 +1,260 @@
+import { Droplet, Thermometer, Wind } from "lucide-react";
+import React, { useCallback, useRef, useState } from "react";
+
+import { Spinner } from "@/components/ui/Spinner";
+import type { HeatmapCell, HeatmapGrid } from "@/lib/heatmapAggregation";
+
+interface ActivityHeatmapProps {
+  grid: HeatmapGrid;
+  peakIntensity: number;
+  rangeLabel: string;
+  taxonomyLabel: string;
+  isLoading?: boolean;
+}
+
+const INTENSITY_STEPS = [0, 0.15, 0.35, 0.6, 1] as const;
+
+function cellColor(count: number, max: number): string {
+  if (max === 0 || count === 0) {
+    return "var(--color-card)";
+  }
+  const ratio = count / max;
+  let step = 0;
+  for (let i = 1; i < INTENSITY_STEPS.length; i++) {
+    if (ratio > INTENSITY_STEPS[i - 1]) {
+      step = i;
+    }
+  }
+  const opacity = 0.15 + step * 0.2;
+  return `color-mix(in oklch, var(--color-chart-2) ${Math.round(opacity * 100)}%, var(--color-card))`;
+}
+
+function ActivityHeatmap({
+  grid,
+  peakIntensity,
+  rangeLabel,
+  taxonomyLabel,
+  isLoading,
+}: ActivityHeatmapProps) {
+  const [hovered, setHovered] = useState<HeatmapCell | null>(null);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0, flipped: false });
+  const gridRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseEnter = useCallback((cell: HeatmapCell, e: React.MouseEvent) => {
+    setHovered(cell);
+    if (gridRef.current) {
+      const gridRect = gridRef.current.getBoundingClientRect();
+      const cellRect = e.currentTarget.getBoundingClientRect();
+      const centerX = cellRect.left + cellRect.width / 2 - gridRect.left;
+      const cellTop = cellRect.top - gridRect.top;
+      const flipped = cellTop < 160;
+      const y = flipped ? cellRect.bottom - gridRect.top + 8 : cellTop - 8;
+      setTooltipPos({ x: centerX, y, flipped });
+    }
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[400px] items-center justify-center rounded border border-border bg-card">
+        <Spinner className="size-6" />
+      </div>
+    );
+  }
+
+  if (grid.cells.length === 0) {
+    return (
+      <div className="flex h-[400px] items-center justify-center rounded border border-border bg-card">
+        <span className="text-sm text-muted-foreground">No data for selected filters</span>
+      </div>
+    );
+  }
+
+  const cols = grid.colLabels.length;
+
+  return (
+    <div className="flex flex-col gap-4 rounded border border-border bg-card p-6">
+      <HeatmapHeader
+        peakIntensity={peakIntensity}
+        rangeLabel={rangeLabel}
+        taxonomyLabel={taxonomyLabel}
+        maxCount={grid.maxCount}
+      />
+
+      <div className="relative" ref={gridRef}>
+        <div className="flex gap-1">
+          <div className="flex flex-col justify-end gap-1 pt-6 pr-2">
+            {grid.rowLabels.map((label) => (
+              <div
+                key={label}
+                className="flex h-7 items-center text-[11px] font-medium text-muted-foreground"
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-1 flex-col gap-1">
+            <div
+              className="grid gap-1"
+              style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+            >
+              {grid.colLabels.map((label) => (
+                <div
+                  key={label}
+                  className="text-center text-[10px] font-medium text-muted-foreground"
+                >
+                  {label}
+                </div>
+              ))}
+            </div>
+
+            {grid.cells.map((row, rowIdx) => (
+              <div
+                key={rowIdx}
+                className="grid gap-1"
+                style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+              >
+                {row.map((cell) => (
+                  <div
+                    key={`${cell.row}-${cell.col}`}
+                    className="h-7 rounded-sm border border-white/[0.06] transition-[outline] duration-100 hover:outline hover:outline-2 hover:outline-foreground/40"
+                    style={{ backgroundColor: cellColor(cell.count, grid.maxCount) }}
+                    onMouseEnter={(e) => handleMouseEnter(cell, e)}
+                    onMouseLeave={() => setHovered(null)}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {hovered && (
+          <CellTooltip
+            ref={tooltipRef}
+            cell={hovered}
+            x={tooltipPos.x}
+            y={tooltipPos.y}
+            flipped={tooltipPos.flipped}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HeatmapHeader({
+  peakIntensity,
+  rangeLabel,
+  taxonomyLabel,
+  maxCount,
+}: {
+  peakIntensity: number;
+  rangeLabel: string;
+  taxonomyLabel: string;
+  maxCount: number;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between">
+        <div>
+          <h4 className="font-bold tracking-tight uppercase">Detection Activity Heatmap</h4>
+          <p className="text-[11px] text-muted-foreground">
+            Activity patterns by {rangeLabel === "day-hour" ? "day and hour" : "week and day"}{" "}
+            (hover for details)
+          </p>
+        </div>
+        <div className="text-right text-[11px] text-muted-foreground">
+          <span>
+            Temporal Resolution:{" "}
+            <strong className="text-foreground">{rangeLabel.toUpperCase()}</strong>
+          </span>
+          <span className="ml-4">
+            Level: <strong className="text-foreground">{taxonomyLabel.toUpperCase()}</strong>
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] text-muted-foreground">Activity:</span>
+          {[0, 0.25, 0.5, 0.75, 1].map((ratio) => (
+            <div
+              key={ratio}
+              className="h-4 w-6 rounded-sm"
+              style={{
+                backgroundColor:
+                  ratio === 0
+                    ? "var(--color-card)"
+                    : `color-mix(in oklch, var(--color-chart-2) ${Math.round((0.15 + ratio * 0.8) * 100)}%, var(--color-card))`,
+                outline: "1px solid rgba(255,255,255,0.06)",
+              }}
+            />
+          ))}
+          <span className="text-[10px] text-muted-foreground">Low</span>
+          <span className="text-[10px] text-muted-foreground">High</span>
+        </div>
+        <span className="text-[11px] text-muted-foreground">
+          Peak Intensity: <strong className="text-foreground">{peakIntensity}</strong> detections
+          {maxCount > 0 ? "/cell" : ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+const CellTooltip = React.forwardRef<
+  HTMLDivElement,
+  { cell: HeatmapCell; x: number; y: number; flipped: boolean }
+>(function CellTooltipInner({ cell, x, y, flipped }, ref) {
+  const arrowBase = "absolute left-1/2 -translate-x-1/2 border-[6px] border-transparent";
+
+  return (
+    <div
+      ref={ref}
+      className="pointer-events-none absolute z-50 min-w-44 -translate-x-1/2 rounded-md border border-border bg-card px-3 py-2 shadow-lg"
+      style={{
+        left: x,
+        ...(flipped ? { top: y } : { bottom: `calc(100% - ${y}px)` }),
+      }}
+    >
+      <p className="text-[11px] font-medium text-muted-foreground uppercase">{cell.label}</p>
+      <p className="mt-0.5 text-lg font-semibold">
+        {cell.count} <span className="text-xs font-normal text-muted-foreground">detections</span>
+      </p>
+      <div className="mt-1.5 flex flex-col gap-1 border-t border-border pt-1.5">
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Thermometer className="h-3 w-3" /> Temp
+          </span>
+          <span className="font-medium">
+            {cell.temp !== undefined ? `${cell.temp}\u00B0C` : "--"}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Droplet className="h-3 w-3" /> Humidity
+          </span>
+          <span className="font-medium">
+            {cell.humidity !== undefined ? `${cell.humidity}%` : "--"}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Wind className="h-3 w-3" /> AQI
+          </span>
+          <span className="font-medium">{cell.aqi !== undefined ? cell.aqi : "--"}</span>
+        </div>
+      </div>
+      {/* Arrow */}
+      <span
+        className={`${arrowBase} ${flipped ? "-top-3 border-b-border" : "-bottom-3 border-t-border"}`}
+      />
+      <span
+        className={`${arrowBase} ${flipped ? "-top-[11px] border-b-card" : "-bottom-[11px] border-t-card"}`}
+      />
+    </div>
+  );
+});
+
+export { ActivityHeatmap };

--- a/src/components/charts/ActivityHeatmap.tsx
+++ b/src/components/charts/ActivityHeatmap.tsx
@@ -101,6 +101,7 @@ function ActivityHeatmap({ grid, taxonomyLabel, isLoading }: ActivityHeatmapProp
 
   const cols = grid.colLabels.length;
   const modeCopy = getModeCopy(grid.mode);
+  const showEnvironmentalData = grid.mode === "date-hour";
 
   return (
     <div className="flex flex-col gap-4 rounded border border-border bg-card p-6">
@@ -173,6 +174,7 @@ function ActivityHeatmap({ grid, taxonomyLabel, isLoading }: ActivityHeatmapProp
         {activeCell && isPointerInside && (
           <CellTooltip
             cell={activeCell}
+            showEnvironmentalData={showEnvironmentalData}
             x={tooltipPos.x}
             y={tooltipPos.y}
             flipped={tooltipPos.flipped}

--- a/src/components/charts/activityHeatmapColors.ts
+++ b/src/components/charts/activityHeatmapColors.ts
@@ -1,0 +1,60 @@
+import type { HeatmapCell, HeatmapMode } from "@/lib/heatmapAggregation";
+
+const MODE_COPY: Record<HeatmapMode, { description: string; structureHint: string }> = {
+  "date-hour": {
+    description: "Activity patterns by date and hour",
+    structureHint: "Rows show dates, columns show hours.",
+  },
+  "week-day": {
+    description: "Activity patterns by week and weekday",
+    structureHint: "Rows show weeks, columns show weekdays.",
+  },
+  "month-weekday": {
+    description: "Activity patterns by month and weekday",
+    structureHint: "Rows show months, columns show weekdays.",
+  },
+};
+
+const HEATMAP_GREEN_RGB = "132, 169, 22";
+
+function getModeCopy(mode: HeatmapMode) {
+  return MODE_COPY[mode];
+}
+
+function cellColorFromRatio(ratio: number): string {
+  if (ratio <= 0) {
+    return "var(--color-card)";
+  }
+
+  const eased = Math.pow(ratio, 1.35);
+  const alpha = 0.14 + eased * 0.72;
+  return `rgba(${HEATMAP_GREEN_RGB}, ${alpha.toFixed(3)})`;
+}
+
+function cellColor(count: number, max: number): string {
+  if (max === 0 || count === 0) {
+    return "var(--color-card)";
+  }
+
+  return cellColorFromRatio(count / max);
+}
+
+function findDefaultCell(cells: HeatmapCell[][]): HeatmapCell | null {
+  if (cells.length === 0) {
+    return null;
+  }
+
+  let bestCell = cells[0]?.[0] ?? null;
+
+  for (const row of cells) {
+    for (const cell of row) {
+      if (!bestCell || cell.count > bestCell.count) {
+        bestCell = cell;
+      }
+    }
+  }
+
+  return bestCell;
+}
+
+export { cellColor, cellColorFromRatio, findDefaultCell, getModeCopy };

--- a/src/components/charts/activityHeatmapParts.tsx
+++ b/src/components/charts/activityHeatmapParts.tsx
@@ -1,0 +1,113 @@
+import { Droplet, Thermometer, Wind } from "lucide-react";
+
+import type { HeatmapCell, HeatmapMode } from "@/lib/heatmapAggregation";
+
+import { cellColorFromRatio, getModeCopy } from "./activityHeatmapColors";
+
+function HeatmapHeader({
+  mode,
+  taxonomyLabel,
+  maxCount,
+}: {
+  mode: HeatmapMode;
+  taxonomyLabel: string;
+  maxCount: number;
+}) {
+  const modeCopy = getModeCopy(mode);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h4 className="font-bold tracking-tight uppercase">Detection Activity Heatmap</h4>
+          <p className="text-[11px] text-muted-foreground">{modeCopy.structureHint}</p>
+        </div>
+        <div className="text-right text-[11px] text-muted-foreground">
+          <span>
+            Level: <strong className="text-foreground">{taxonomyLabel.toUpperCase()}</strong>
+          </span>
+          <span className="ml-4">
+            Peak: <strong className="text-foreground">{maxCount}</strong> detections/cell
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] text-muted-foreground">Activity:</span>
+          {[0, 0.25, 0.5, 0.75, 1].map((ratio) => (
+            <div
+              key={ratio}
+              className="h-4 w-6 rounded-sm"
+              style={{
+                backgroundColor: cellColorFromRatio(ratio),
+                outline: "1px solid rgba(255,255,255,0.06)",
+              }}
+            />
+          ))}
+          <span className="text-[10px] text-muted-foreground">Low</span>
+          <span className="text-[10px] text-muted-foreground">High</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CellTooltip({
+  cell,
+  x,
+  y,
+  flipped,
+}: {
+  cell: HeatmapCell;
+  x: number;
+  y: number;
+  flipped: boolean;
+}) {
+  const arrowBase = "absolute left-1/2 -translate-x-1/2 border-[6px] border-transparent";
+
+  return (
+    <div
+      className="pointer-events-none absolute z-50 min-w-52 -translate-x-1/2 rounded-md border border-border bg-card px-3 py-2 shadow-lg"
+      style={{
+        left: x,
+        ...(flipped ? { top: y } : { bottom: `calc(100% - ${y}px)` }),
+      }}
+    >
+      <p className="text-[11px] font-medium text-muted-foreground uppercase">{cell.label}</p>
+      <p className="mt-0.5 text-lg font-semibold">
+        {cell.count} <span className="text-xs font-normal text-muted-foreground">detections</span>
+      </p>
+      <div className="mt-1.5 flex flex-col gap-1 border-t border-border pt-1.5">
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Thermometer className="h-3 w-3" /> Temp
+          </span>
+          <span className="font-medium">{cell.temp !== undefined ? `${cell.temp}°C` : "--"}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Droplet className="h-3 w-3" /> Humidity
+          </span>
+          <span className="font-medium">
+            {cell.humidity !== undefined ? `${cell.humidity}%` : "--"}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Wind className="h-3 w-3" /> AQI
+          </span>
+          <span className="font-medium">{cell.aqi !== undefined ? cell.aqi : "--"}</span>
+        </div>
+      </div>
+      <span
+        className={`${arrowBase} ${flipped ? "-top-3 border-b-border" : "-bottom-3 border-t-border"}`}
+      />
+      <span
+        className={`${arrowBase} ${flipped ? "-top-[11px] border-b-card" : "-bottom-[11px] border-t-card"}`}
+      />
+    </div>
+  );
+}
+
+export { CellTooltip, HeatmapHeader };

--- a/src/components/charts/activityHeatmapParts.tsx
+++ b/src/components/charts/activityHeatmapParts.tsx
@@ -55,11 +55,13 @@ function HeatmapHeader({
 
 function CellTooltip({
   cell,
+  showEnvironmentalData,
   x,
   y,
   flipped,
 }: {
   cell: HeatmapCell;
+  showEnvironmentalData: boolean;
   x: number;
   y: number;
   flipped: boolean;
@@ -78,28 +80,30 @@ function CellTooltip({
       <p className="mt-0.5 text-lg font-semibold">
         {cell.count} <span className="text-xs font-normal text-muted-foreground">detections</span>
       </p>
-      <div className="mt-1.5 flex flex-col gap-1 border-t border-border pt-1.5">
-        <div className="flex items-center justify-between gap-4 text-xs">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <Thermometer className="h-3 w-3" /> Temp
-          </span>
-          <span className="font-medium">{cell.temp !== undefined ? `${cell.temp}°C` : "--"}</span>
+      {showEnvironmentalData && (
+        <div className="mt-1.5 flex flex-col gap-1 border-t border-border pt-1.5">
+          <div className="flex items-center justify-between gap-4 text-xs">
+            <span className="flex items-center gap-1 text-muted-foreground">
+              <Thermometer className="h-3 w-3" /> Temp
+            </span>
+            <span className="font-medium">{cell.temp !== undefined ? `${cell.temp}°C` : "--"}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4 text-xs">
+            <span className="flex items-center gap-1 text-muted-foreground">
+              <Droplet className="h-3 w-3" /> Humidity
+            </span>
+            <span className="font-medium">
+              {cell.humidity !== undefined ? `${cell.humidity}%` : "--"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-4 text-xs">
+            <span className="flex items-center gap-1 text-muted-foreground">
+              <Wind className="h-3 w-3" /> AQI
+            </span>
+            <span className="font-medium">{cell.aqi !== undefined ? cell.aqi : "--"}</span>
+          </div>
         </div>
-        <div className="flex items-center justify-between gap-4 text-xs">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <Droplet className="h-3 w-3" /> Humidity
-          </span>
-          <span className="font-medium">
-            {cell.humidity !== undefined ? `${cell.humidity}%` : "--"}
-          </span>
-        </div>
-        <div className="flex items-center justify-between gap-4 text-xs">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <Wind className="h-3 w-3" /> AQI
-          </span>
-          <span className="font-medium">{cell.aqi !== undefined ? cell.aqi : "--"}</span>
-        </div>
-      </div>
+      )}
       <span
         className={`${arrowBase} ${flipped ? "-top-3 border-b-border" : "-bottom-3 border-t-border"}`}
       />

--- a/src/components/filters/DateRangeFilter.tsx
+++ b/src/components/filters/DateRangeFilter.tsx
@@ -20,10 +20,32 @@ const presets: { value: RangePreset; label: string }[] = [
   { value: "24h", label: "Last 24 Hours" },
   { value: "7d", label: "Last 7 Days" },
   { value: "30d", label: "Last 30 Days" },
+  { value: "custom", label: "Custom Range" },
 ];
 
+function toDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+const dateInputClass =
+  "h-8 w-full rounded border border-border bg-card px-2 text-sm text-foreground outline-none transition-colors hover:border-muted-foreground focus:ring-1 focus:ring-ring [&::-webkit-calendar-picker-indicator]:invert";
+
 function DateRangeFilter() {
-  const { updateFilters, rangePreset } = useFilters();
+  const { updateFilters, rangePreset, startDate, endDate } = useFilters();
+
+  const handlePresetChange = (value: string) => {
+    if (value === "custom") {
+      const now = new Date();
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      updateFilters({
+        rangePreset: "custom",
+        startDate: toDateString(weekAgo),
+        endDate: toDateString(now),
+      });
+    } else {
+      updateFilters({ rangePreset: value as RangePreset, startDate: "", endDate: "" });
+    }
+  };
 
   return (
     <div className={filterFieldClass}>
@@ -31,15 +53,10 @@ function DateRangeFilter() {
         <CalendarIcon className="h-3 w-3" />
         Date Range
       </Label>
-      <Select
-        value={rangePreset}
-        onValueChange={(value) =>
-          updateFilters({ rangePreset: (value as RangePreset) ?? undefined })
-        }
-      >
+      <Select value={rangePreset} onValueChange={(v) => v && handlePresetChange(v)}>
         <SelectTrigger id="filter-date-range" className={filterSelectClass}>
           <SelectValue>
-            {presets.find((preset) => preset.value === rangePreset)?.label ?? "Custom"}
+            {presets.find((p) => p.value === rangePreset)?.label ?? "Custom Range"}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
@@ -50,6 +67,26 @@ function DateRangeFilter() {
           ))}
         </SelectContent>
       </Select>
+
+      {rangePreset === "custom" && (
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            aria-label="Start date"
+            className={dateInputClass}
+            value={startDate ? startDate.slice(0, 10) : ""}
+            onChange={(e) => updateFilters({ startDate: e.target.value })}
+          />
+          <span className="shrink-0 text-xs text-muted-foreground">to</span>
+          <input
+            type="date"
+            aria-label="End date"
+            className={dateInputClass}
+            value={endDate ? endDate.slice(0, 10) : ""}
+            onChange={(e) => updateFilters({ endDate: e.target.value })}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -1,3 +1,4 @@
+import { getObservationConfidence } from "@/lib/confidence";
 import type { Observation, TaxonomyLevel } from "@/lib/types/api";
 
 // --- Time aggregation ---
@@ -108,10 +109,9 @@ function aggregateByTime(
   const effectiveStart = startTime || deriveRange(observations).startTime;
   const effectiveEnd = endTime || deriveRange(observations).endTime;
   const buckets = generateEmptyBuckets(effectiveStart, effectiveEnd, bucket);
-  const confKey = `${taxonomyLevel}_confidence` as keyof Observation;
 
   for (const obs of observations) {
-    const confidence = (obs[confKey] as number | undefined) ?? 0;
+    const confidence = getObservationConfidence(obs, taxonomyLevel);
     if (confidence < minConfidence) {
       continue;
     }
@@ -141,11 +141,10 @@ function aggregateByTaxonomy(
   minConfidence: number = 0,
   topN: number = 10,
 ): TaxonCount[] {
-  const confKey = `${taxonomyLevel}_confidence` as keyof Observation;
   const counts = new Map<string, number>();
 
   for (const obs of observations) {
-    const confidence = (obs[confKey] as number | undefined) ?? 0;
+    const confidence = getObservationConfidence(obs, taxonomyLevel);
     if (confidence < minConfidence) {
       continue;
     }

--- a/src/lib/confidence.ts
+++ b/src/lib/confidence.ts
@@ -1,0 +1,18 @@
+import type { TaxonomyLevel } from "@/lib/filters";
+import type { Observation } from "@/lib/types/api";
+
+function normalizeConfidenceValue(confidence: number | undefined): number {
+  if (confidence === undefined || Number.isNaN(confidence)) {
+    return 0;
+  }
+
+  return confidence <= 1 ? confidence * 100 : confidence;
+}
+
+function getObservationConfidence(observation: Observation, taxonomyLevel: TaxonomyLevel): number {
+  const confidenceKey = `${taxonomyLevel}_confidence` as keyof Observation;
+  const confidence = observation[confidenceKey] as number | undefined;
+  return normalizeConfidenceValue(confidence);
+}
+
+export { getObservationConfidence, normalizeConfidenceValue };

--- a/src/lib/heatmapAggregation.ts
+++ b/src/lib/heatmapAggregation.ts
@@ -1,244 +1,13 @@
 import type { TaxonomyLevel } from "@/lib/filters";
 import type { EnvironmentData, Observation } from "@/lib/types/api";
 
-interface HeatmapCell {
-  row: number;
-  col: number;
-  count: number;
-  label: string;
-  temp?: number;
-  humidity?: number;
-  aqi?: number;
-}
-
-interface HeatmapGrid {
-  cells: HeatmapCell[][];
-  rowLabels: string[];
-  colLabels: string[];
-  maxCount: number;
-}
-
-type HeatmapMode = "day-hour" | "week-day";
-
-const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const HOUR_LABELS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0"));
-
-/**
- * Picks grid layout from date range. Currently:
- * - day-hour: ≤7 days → rows = weekdays (7), cols = hours (24).
- * - week-day: else → rows = weeks (can be many), cols = weekdays (7).
- * Limitation: custom ranges like 1 year produce ~52 week-rows; consider adding
- * a "month-day" mode (rows = months, max 12) for spans > ~12 weeks.
- */
-function pickHeatmapMode(rangePreset: string, startDate: string, endDate: string): HeatmapMode {
-  if (rangePreset === "24h" || rangePreset === "7d") {
-    return "day-hour";
-  }
-  if (rangePreset === "custom" && startDate && endDate) {
-    const diffMs = new Date(endDate).getTime() - new Date(startDate).getTime();
-    const diffDays = diffMs / (1000 * 60 * 60 * 24);
-    return diffDays <= 7 ? "day-hour" : "week-day";
-  }
-  return "week-day";
-}
-
-function jsDayToMondayIndex(jsDay: number): number {
-  return jsDay === 0 ? 6 : jsDay - 1;
-}
-
-function filterObservations(
-  observations: Observation[],
-  minConfidence: number,
-  taxonomyLevel: TaxonomyLevel,
-): Observation[] {
-  const confKey = `${taxonomyLevel}_confidence` as keyof Observation;
-  return observations.filter((obs) => {
-    const conf = (obs[confKey] as number | undefined) ?? 0;
-    return conf >= minConfidence;
-  });
-}
-
-function buildEnvLookup(
-  envData: EnvironmentData[],
-): Map<string, { temps: number[]; humidities: number[]; aqis: number[] }> {
-  const lookup = new Map<string, { temps: number[]; humidities: number[]; aqis: number[] }>();
-
-  for (const e of envData) {
-    const d = new Date(e.timestamp);
-    const dayIdx = jsDayToMondayIndex(d.getDay());
-    const hour = d.getHours();
-    const key = `${dayIdx}-${hour}`;
-
-    let bucket = lookup.get(key);
-    if (!bucket) {
-      bucket = { temps: [], humidities: [], aqis: [] };
-      lookup.set(key, bucket);
-    }
-    if (e.ambient_temperature !== undefined) {
-      bucket.temps.push(e.ambient_temperature);
-    }
-    if (e.ambient_humidity !== undefined) {
-      bucket.humidities.push(e.ambient_humidity);
-    }
-    if (e.voc_index !== undefined) {
-      bucket.aqis.push(e.voc_index);
-    }
-  }
-
-  return lookup;
-}
-
-function avg(arr: number[]): number | undefined {
-  if (arr.length === 0) {
-    return undefined;
-  }
-  return Math.round((arr.reduce((a, b) => a + b, 0) / arr.length) * 10) / 10;
-}
-
-function buildWeekEnvLookup(
-  envData: EnvironmentData[],
-  weekStart: Date,
-): Map<string, { temps: number[]; humidities: number[]; aqis: number[] }> {
-  const lookup = new Map<string, { temps: number[]; humidities: number[]; aqis: number[] }>();
-  const weekStartMs = weekStart.getTime();
-
-  for (const e of envData) {
-    const d = new Date(e.timestamp);
-    const weekIdx = Math.floor((d.getTime() - weekStartMs) / (7 * 24 * 60 * 60 * 1000));
-    const dayIdx = jsDayToMondayIndex(d.getDay());
-    const key = `${weekIdx}-${dayIdx}`;
-
-    let bucket = lookup.get(key);
-    if (!bucket) {
-      bucket = { temps: [], humidities: [], aqis: [] };
-      lookup.set(key, bucket);
-    }
-    if (e.ambient_temperature !== undefined) {
-      bucket.temps.push(e.ambient_temperature);
-    }
-    if (e.ambient_humidity !== undefined) {
-      bucket.humidities.push(e.ambient_humidity);
-    }
-    if (e.voc_index !== undefined) {
-      bucket.aqis.push(e.voc_index);
-    }
-  }
-
-  return lookup;
-}
-
-function aggregateHeatmapDayHour(
-  observations: Observation[],
-  envData: EnvironmentData[],
-): HeatmapGrid {
-  const rows = 7;
-  const cols = 24;
-
-  const cells: HeatmapCell[][] = Array.from({ length: rows }, (_r, row) =>
-    Array.from({ length: cols }, (_c, col) => ({
-      row,
-      col,
-      count: 0,
-      label: `${DAY_LABELS[row]} @ ${HOUR_LABELS[col]}:00`,
-    })),
-  );
-
-  for (const obs of observations) {
-    const d = new Date(obs.timestamp);
-    const row = jsDayToMondayIndex(d.getDay());
-    const col = d.getHours();
-    cells[row][col].count++;
-  }
-
-  const envLookup = buildEnvLookup(envData);
-  for (let row = 0; row < rows; row++) {
-    for (let col = 0; col < cols; col++) {
-      const bucket = envLookup.get(`${row}-${col}`);
-      if (bucket) {
-        cells[row][col].temp = avg(bucket.temps);
-        cells[row][col].humidity = avg(bucket.humidities);
-        cells[row][col].aqi = avg(bucket.aqis);
-      }
-    }
-  }
-
-  let maxCount = 0;
-  for (const row of cells) {
-    for (const cell of row) {
-      if (cell.count > maxCount) {
-        maxCount = cell.count;
-      }
-    }
-  }
-
-  return { cells, rowLabels: [...DAY_LABELS], colLabels: [...HOUR_LABELS], maxCount };
-}
-
-function aggregateHeatmapWeekDay(
-  observations: Observation[],
-  envData: EnvironmentData[],
-  startDate: string,
-  endDate: string,
-): HeatmapGrid {
-  const start = new Date(startDate);
-  const end = new Date(endDate);
-  const diffMs = end.getTime() - start.getTime();
-  const totalWeeks = Math.max(1, Math.ceil(diffMs / (7 * 24 * 60 * 60 * 1000)));
-
-  const rows = totalWeeks;
-  const cols = 7;
-
-  const mondayOfStart = new Date(start);
-  const startDow = mondayOfStart.getDay();
-  const mondayOffset = startDow === 0 ? -6 : 1 - startDow;
-  mondayOfStart.setDate(mondayOfStart.getDate() + mondayOffset);
-  mondayOfStart.setHours(0, 0, 0, 0);
-
-  const rowLabels = Array.from({ length: rows }, (_, i) => `Week ${i + 1}`);
-
-  const cells: HeatmapCell[][] = Array.from({ length: rows }, (_r, row) =>
-    Array.from({ length: cols }, (_c, col) => ({
-      row,
-      col,
-      count: 0,
-      label: `${rowLabels[row]}, ${DAY_LABELS[col]}`,
-    })),
-  );
-
-  const weekStartMs = mondayOfStart.getTime();
-
-  for (const obs of observations) {
-    const d = new Date(obs.timestamp);
-    const weekIdx = Math.floor((d.getTime() - weekStartMs) / (7 * 24 * 60 * 60 * 1000));
-    const dayIdx = jsDayToMondayIndex(d.getDay());
-    if (weekIdx >= 0 && weekIdx < rows && dayIdx >= 0 && dayIdx < cols) {
-      cells[weekIdx][dayIdx].count++;
-    }
-  }
-
-  const envLookup = buildWeekEnvLookup(envData, mondayOfStart);
-  for (let row = 0; row < rows; row++) {
-    for (let col = 0; col < cols; col++) {
-      const bucket = envLookup.get(`${row}-${col}`);
-      if (bucket) {
-        cells[row][col].temp = avg(bucket.temps);
-        cells[row][col].humidity = avg(bucket.humidities);
-        cells[row][col].aqi = avg(bucket.aqis);
-      }
-    }
-  }
-
-  let maxCount = 0;
-  for (const row of cells) {
-    for (const cell of row) {
-      if (cell.count > maxCount) {
-        maxCount = cell.count;
-      }
-    }
-  }
-
-  return { cells, rowLabels, colLabels: [...DAY_LABELS], maxCount };
-}
+import {
+  aggregateHeatmapDateHour,
+  aggregateHeatmapMonthWeekday,
+  aggregateHeatmapWeekDay,
+} from "./heatmapAggregationBuilders";
+import { filterObservations, pickHeatmapMode } from "./heatmapAggregationCore";
+import type { HeatmapCell, HeatmapGrid, HeatmapMode } from "./heatmapAggregationCore";
 
 function aggregateHeatmap(
   observations: Observation[],
@@ -252,10 +21,15 @@ function aggregateHeatmap(
   const filtered = filterObservations(observations, minConfidence, taxonomyLevel);
   const mode = pickHeatmapMode(rangePreset, startDate, endDate);
 
-  if (mode === "day-hour") {
-    return aggregateHeatmapDayHour(filtered, envData);
+  if (mode === "date-hour") {
+    return aggregateHeatmapDateHour(filtered, envData, startDate, endDate);
   }
-  return aggregateHeatmapWeekDay(filtered, envData, startDate, endDate);
+
+  if (mode === "week-day") {
+    return aggregateHeatmapWeekDay(filtered, envData, startDate, endDate);
+  }
+
+  return aggregateHeatmapMonthWeekday(filtered, envData, startDate, endDate);
 }
 
 export { aggregateHeatmap, pickHeatmapMode };

--- a/src/lib/heatmapAggregation.ts
+++ b/src/lib/heatmapAggregation.ts
@@ -23,6 +23,13 @@ type HeatmapMode = "day-hour" | "week-day";
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const HOUR_LABELS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0"));
 
+/**
+ * Picks grid layout from date range. Currently:
+ * - day-hour: ≤7 days → rows = weekdays (7), cols = hours (24).
+ * - week-day: else → rows = weeks (can be many), cols = weekdays (7).
+ * Limitation: custom ranges like 1 year produce ~52 week-rows; consider adding
+ * a "month-day" mode (rows = months, max 12) for spans > ~12 weeks.
+ */
 function pickHeatmapMode(rangePreset: string, startDate: string, endDate: string): HeatmapMode {
   if (rangePreset === "24h" || rangePreset === "7d") {
     return "day-hour";

--- a/src/lib/heatmapAggregation.ts
+++ b/src/lib/heatmapAggregation.ts
@@ -1,0 +1,255 @@
+import type { TaxonomyLevel } from "@/lib/filters";
+import type { EnvironmentData, Observation } from "@/lib/types/api";
+
+interface HeatmapCell {
+  row: number;
+  col: number;
+  count: number;
+  label: string;
+  temp?: number;
+  humidity?: number;
+  aqi?: number;
+}
+
+interface HeatmapGrid {
+  cells: HeatmapCell[][];
+  rowLabels: string[];
+  colLabels: string[];
+  maxCount: number;
+}
+
+type HeatmapMode = "day-hour" | "week-day";
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const HOUR_LABELS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0"));
+
+function pickHeatmapMode(rangePreset: string, startDate: string, endDate: string): HeatmapMode {
+  if (rangePreset === "24h" || rangePreset === "7d") {
+    return "day-hour";
+  }
+  if (rangePreset === "custom" && startDate && endDate) {
+    const diffMs = new Date(endDate).getTime() - new Date(startDate).getTime();
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    return diffDays <= 7 ? "day-hour" : "week-day";
+  }
+  return "week-day";
+}
+
+function jsDayToMondayIndex(jsDay: number): number {
+  return jsDay === 0 ? 6 : jsDay - 1;
+}
+
+function filterObservations(
+  observations: Observation[],
+  minConfidence: number,
+  taxonomyLevel: TaxonomyLevel,
+): Observation[] {
+  const confKey = `${taxonomyLevel}_confidence` as keyof Observation;
+  return observations.filter((obs) => {
+    const conf = (obs[confKey] as number | undefined) ?? 0;
+    return conf >= minConfidence;
+  });
+}
+
+function buildEnvLookup(
+  envData: EnvironmentData[],
+): Map<string, { temps: number[]; humidities: number[]; aqis: number[] }> {
+  const lookup = new Map<string, { temps: number[]; humidities: number[]; aqis: number[] }>();
+
+  for (const e of envData) {
+    const d = new Date(e.timestamp);
+    const dayIdx = jsDayToMondayIndex(d.getDay());
+    const hour = d.getHours();
+    const key = `${dayIdx}-${hour}`;
+
+    let bucket = lookup.get(key);
+    if (!bucket) {
+      bucket = { temps: [], humidities: [], aqis: [] };
+      lookup.set(key, bucket);
+    }
+    if (e.ambient_temperature !== undefined) {
+      bucket.temps.push(e.ambient_temperature);
+    }
+    if (e.ambient_humidity !== undefined) {
+      bucket.humidities.push(e.ambient_humidity);
+    }
+    if (e.voc_index !== undefined) {
+      bucket.aqis.push(e.voc_index);
+    }
+  }
+
+  return lookup;
+}
+
+function avg(arr: number[]): number | undefined {
+  if (arr.length === 0) {
+    return undefined;
+  }
+  return Math.round((arr.reduce((a, b) => a + b, 0) / arr.length) * 10) / 10;
+}
+
+function buildWeekEnvLookup(
+  envData: EnvironmentData[],
+  weekStart: Date,
+): Map<string, { temps: number[]; humidities: number[]; aqis: number[] }> {
+  const lookup = new Map<string, { temps: number[]; humidities: number[]; aqis: number[] }>();
+  const weekStartMs = weekStart.getTime();
+
+  for (const e of envData) {
+    const d = new Date(e.timestamp);
+    const weekIdx = Math.floor((d.getTime() - weekStartMs) / (7 * 24 * 60 * 60 * 1000));
+    const dayIdx = jsDayToMondayIndex(d.getDay());
+    const key = `${weekIdx}-${dayIdx}`;
+
+    let bucket = lookup.get(key);
+    if (!bucket) {
+      bucket = { temps: [], humidities: [], aqis: [] };
+      lookup.set(key, bucket);
+    }
+    if (e.ambient_temperature !== undefined) {
+      bucket.temps.push(e.ambient_temperature);
+    }
+    if (e.ambient_humidity !== undefined) {
+      bucket.humidities.push(e.ambient_humidity);
+    }
+    if (e.voc_index !== undefined) {
+      bucket.aqis.push(e.voc_index);
+    }
+  }
+
+  return lookup;
+}
+
+function aggregateHeatmapDayHour(
+  observations: Observation[],
+  envData: EnvironmentData[],
+): HeatmapGrid {
+  const rows = 7;
+  const cols = 24;
+
+  const cells: HeatmapCell[][] = Array.from({ length: rows }, (_r, row) =>
+    Array.from({ length: cols }, (_c, col) => ({
+      row,
+      col,
+      count: 0,
+      label: `${DAY_LABELS[row]} @ ${HOUR_LABELS[col]}:00`,
+    })),
+  );
+
+  for (const obs of observations) {
+    const d = new Date(obs.timestamp);
+    const row = jsDayToMondayIndex(d.getDay());
+    const col = d.getHours();
+    cells[row][col].count++;
+  }
+
+  const envLookup = buildEnvLookup(envData);
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const bucket = envLookup.get(`${row}-${col}`);
+      if (bucket) {
+        cells[row][col].temp = avg(bucket.temps);
+        cells[row][col].humidity = avg(bucket.humidities);
+        cells[row][col].aqi = avg(bucket.aqis);
+      }
+    }
+  }
+
+  let maxCount = 0;
+  for (const row of cells) {
+    for (const cell of row) {
+      if (cell.count > maxCount) {
+        maxCount = cell.count;
+      }
+    }
+  }
+
+  return { cells, rowLabels: [...DAY_LABELS], colLabels: [...HOUR_LABELS], maxCount };
+}
+
+function aggregateHeatmapWeekDay(
+  observations: Observation[],
+  envData: EnvironmentData[],
+  startDate: string,
+  endDate: string,
+): HeatmapGrid {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const diffMs = end.getTime() - start.getTime();
+  const totalWeeks = Math.max(1, Math.ceil(diffMs / (7 * 24 * 60 * 60 * 1000)));
+
+  const rows = totalWeeks;
+  const cols = 7;
+
+  const mondayOfStart = new Date(start);
+  const startDow = mondayOfStart.getDay();
+  const mondayOffset = startDow === 0 ? -6 : 1 - startDow;
+  mondayOfStart.setDate(mondayOfStart.getDate() + mondayOffset);
+  mondayOfStart.setHours(0, 0, 0, 0);
+
+  const rowLabels = Array.from({ length: rows }, (_, i) => `Week ${i + 1}`);
+
+  const cells: HeatmapCell[][] = Array.from({ length: rows }, (_r, row) =>
+    Array.from({ length: cols }, (_c, col) => ({
+      row,
+      col,
+      count: 0,
+      label: `${rowLabels[row]}, ${DAY_LABELS[col]}`,
+    })),
+  );
+
+  const weekStartMs = mondayOfStart.getTime();
+
+  for (const obs of observations) {
+    const d = new Date(obs.timestamp);
+    const weekIdx = Math.floor((d.getTime() - weekStartMs) / (7 * 24 * 60 * 60 * 1000));
+    const dayIdx = jsDayToMondayIndex(d.getDay());
+    if (weekIdx >= 0 && weekIdx < rows && dayIdx >= 0 && dayIdx < cols) {
+      cells[weekIdx][dayIdx].count++;
+    }
+  }
+
+  const envLookup = buildWeekEnvLookup(envData, mondayOfStart);
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const bucket = envLookup.get(`${row}-${col}`);
+      if (bucket) {
+        cells[row][col].temp = avg(bucket.temps);
+        cells[row][col].humidity = avg(bucket.humidities);
+        cells[row][col].aqi = avg(bucket.aqis);
+      }
+    }
+  }
+
+  let maxCount = 0;
+  for (const row of cells) {
+    for (const cell of row) {
+      if (cell.count > maxCount) {
+        maxCount = cell.count;
+      }
+    }
+  }
+
+  return { cells, rowLabels, colLabels: [...DAY_LABELS], maxCount };
+}
+
+function aggregateHeatmap(
+  observations: Observation[],
+  envData: EnvironmentData[],
+  startDate: string,
+  endDate: string,
+  rangePreset: string,
+  minConfidence: number = 0,
+  taxonomyLevel: TaxonomyLevel = "family",
+): HeatmapGrid {
+  const filtered = filterObservations(observations, minConfidence, taxonomyLevel);
+  const mode = pickHeatmapMode(rangePreset, startDate, endDate);
+
+  if (mode === "day-hour") {
+    return aggregateHeatmapDayHour(filtered, envData);
+  }
+  return aggregateHeatmapWeekDay(filtered, envData, startDate, endDate);
+}
+
+export { aggregateHeatmap, pickHeatmapMode };
+export type { HeatmapCell, HeatmapGrid, HeatmapMode };

--- a/src/lib/heatmapAggregationBuilders.ts
+++ b/src/lib/heatmapAggregationBuilders.ts
@@ -94,7 +94,7 @@ function enumerateWeeks(startDate: string, endDate: string): Date[] {
 
 function aggregateHeatmapWeekDay(
   observations: Observation[],
-  envData: EnvironmentData[],
+  _envData: EnvironmentData[],
   startDate: string,
   endDate: string,
 ): HeatmapGrid {
@@ -122,16 +122,6 @@ function aggregateHeatmapWeekDay(
 
     cells[row][col].count++;
   }
-
-  const envLookup = buildEnvLookup(envData, (date) => {
-    const row = weekIndexes.get(getWeekStart(date).getTime());
-    if (row === undefined) {
-      return null;
-    }
-    return `${row}-${jsDayToMondayIndex(date.getDay())}`;
-  });
-
-  applyEnvData(cells, envLookup);
 
   return {
     cells,
@@ -162,7 +152,7 @@ function enumerateMonths(startDate: string, endDate: string): Date[] {
 
 function aggregateHeatmapMonthWeekday(
   observations: Observation[],
-  envData: EnvironmentData[],
+  _envData: EnvironmentData[],
   startDate: string,
   endDate: string,
 ): HeatmapGrid {
@@ -190,16 +180,6 @@ function aggregateHeatmapMonthWeekday(
 
     cells[row][col].count++;
   }
-
-  const envLookup = buildEnvLookup(envData, (date) => {
-    const row = monthIndexes.get(formatMonthKey(date));
-    if (row === undefined) {
-      return null;
-    }
-    return `${row}-${jsDayToMondayIndex(date.getDay())}`;
-  });
-
-  applyEnvData(cells, envLookup);
 
   return {
     cells,

--- a/src/lib/heatmapAggregationBuilders.ts
+++ b/src/lib/heatmapAggregationBuilders.ts
@@ -1,0 +1,213 @@
+import type { EnvironmentData, Observation } from "@/lib/types/api";
+
+import {
+  DAY_LABELS,
+  HOUR_LABELS,
+  applyEnvData,
+  buildEnvLookup,
+  formatDateKey,
+  formatMonthKey,
+  getMaxCount,
+  getStartOfDay,
+  getWeekStart,
+  jsDayToMondayIndex,
+  monthDayFormatter,
+  monthFormatter,
+} from "./heatmapAggregationCore";
+import type { HeatmapCell, HeatmapGrid } from "./heatmapAggregationCore";
+
+function enumerateDates(startDate: string, endDate: string): Date[] {
+  const dates: Date[] = [];
+  const current = getStartOfDay(new Date(startDate));
+  const end = getStartOfDay(new Date(endDate));
+
+  while (current.getTime() <= end.getTime()) {
+    dates.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+function aggregateHeatmapDateHour(
+  observations: Observation[],
+  envData: EnvironmentData[],
+  startDate: string,
+  endDate: string,
+): HeatmapGrid {
+  const dates = enumerateDates(startDate, endDate);
+  const rowLabels = dates.map((date) => monthDayFormatter.format(date));
+  const rowIndexes = new Map(dates.map((date, index) => [formatDateKey(date), index]));
+
+  const cells: HeatmapCell[][] = Array.from({ length: dates.length }, (_unused, row) =>
+    Array.from({ length: 24 }, (_unusedCol, col) => ({
+      row,
+      col,
+      count: 0,
+      label: `${rowLabels[row]} @ ${HOUR_LABELS[col]}:00`,
+    })),
+  );
+
+  for (const obs of observations) {
+    const date = new Date(obs.timestamp);
+    const row = rowIndexes.get(formatDateKey(date));
+    const col = date.getHours();
+
+    if (row === undefined) {
+      continue;
+    }
+
+    cells[row][col].count++;
+  }
+
+  const envLookup = buildEnvLookup(envData, (date) => {
+    const row = rowIndexes.get(formatDateKey(date));
+    if (row === undefined) {
+      return null;
+    }
+    return `${row}-${date.getHours()}`;
+  });
+
+  applyEnvData(cells, envLookup);
+
+  return {
+    cells,
+    rowLabels,
+    colLabels: [...HOUR_LABELS],
+    maxCount: getMaxCount(cells),
+    mode: "date-hour",
+  };
+}
+
+function enumerateWeeks(startDate: string, endDate: string): Date[] {
+  const weeks: Date[] = [];
+  const current = getWeekStart(new Date(startDate));
+  const end = getWeekStart(new Date(endDate));
+
+  while (current.getTime() <= end.getTime()) {
+    weeks.push(new Date(current));
+    current.setDate(current.getDate() + 7);
+  }
+
+  return weeks;
+}
+
+function aggregateHeatmapWeekDay(
+  observations: Observation[],
+  envData: EnvironmentData[],
+  startDate: string,
+  endDate: string,
+): HeatmapGrid {
+  const weeks = enumerateWeeks(startDate, endDate);
+  const rowLabels = weeks.map((week) => `Week of ${monthDayFormatter.format(week)}`);
+  const weekIndexes = new Map(weeks.map((week, index) => [week.getTime(), index]));
+
+  const cells: HeatmapCell[][] = Array.from({ length: weeks.length }, (_unused, row) =>
+    Array.from({ length: 7 }, (_unusedCol, col) => ({
+      row,
+      col,
+      count: 0,
+      label: `${rowLabels[row]}, ${DAY_LABELS[col]}`,
+    })),
+  );
+
+  for (const obs of observations) {
+    const date = new Date(obs.timestamp);
+    const row = weekIndexes.get(getWeekStart(date).getTime());
+    const col = jsDayToMondayIndex(date.getDay());
+
+    if (row === undefined) {
+      continue;
+    }
+
+    cells[row][col].count++;
+  }
+
+  const envLookup = buildEnvLookup(envData, (date) => {
+    const row = weekIndexes.get(getWeekStart(date).getTime());
+    if (row === undefined) {
+      return null;
+    }
+    return `${row}-${jsDayToMondayIndex(date.getDay())}`;
+  });
+
+  applyEnvData(cells, envLookup);
+
+  return {
+    cells,
+    rowLabels,
+    colLabels: [...DAY_LABELS],
+    maxCount: getMaxCount(cells),
+    mode: "week-day",
+  };
+}
+
+function enumerateMonths(startDate: string, endDate: string): Date[] {
+  const months: Date[] = [];
+  const current = new Date(startDate);
+  current.setDate(1);
+  current.setHours(0, 0, 0, 0);
+
+  const end = new Date(endDate);
+  end.setDate(1);
+  end.setHours(0, 0, 0, 0);
+
+  while (current.getTime() <= end.getTime()) {
+    months.push(new Date(current));
+    current.setMonth(current.getMonth() + 1);
+  }
+
+  return months;
+}
+
+function aggregateHeatmapMonthWeekday(
+  observations: Observation[],
+  envData: EnvironmentData[],
+  startDate: string,
+  endDate: string,
+): HeatmapGrid {
+  const months = enumerateMonths(startDate, endDate);
+  const rowLabels = months.map((month) => monthFormatter.format(month));
+  const monthIndexes = new Map(months.map((month, index) => [formatMonthKey(month), index]));
+
+  const cells: HeatmapCell[][] = Array.from({ length: months.length }, (_unused, row) =>
+    Array.from({ length: 7 }, (_unusedCol, col) => ({
+      row,
+      col,
+      count: 0,
+      label: `${rowLabels[row]}, ${DAY_LABELS[col]}`,
+    })),
+  );
+
+  for (const obs of observations) {
+    const date = new Date(obs.timestamp);
+    const row = monthIndexes.get(formatMonthKey(date));
+    const col = jsDayToMondayIndex(date.getDay());
+
+    if (row === undefined) {
+      continue;
+    }
+
+    cells[row][col].count++;
+  }
+
+  const envLookup = buildEnvLookup(envData, (date) => {
+    const row = monthIndexes.get(formatMonthKey(date));
+    if (row === undefined) {
+      return null;
+    }
+    return `${row}-${jsDayToMondayIndex(date.getDay())}`;
+  });
+
+  applyEnvData(cells, envLookup);
+
+  return {
+    cells,
+    rowLabels,
+    colLabels: [...DAY_LABELS],
+    maxCount: getMaxCount(cells),
+    mode: "month-weekday",
+  };
+}
+
+export { aggregateHeatmapDateHour, aggregateHeatmapMonthWeekday, aggregateHeatmapWeekDay };

--- a/src/lib/heatmapAggregationCore.ts
+++ b/src/lib/heatmapAggregationCore.ts
@@ -1,0 +1,191 @@
+import { getObservationConfidence } from "@/lib/confidence";
+import type { TaxonomyLevel } from "@/lib/filters";
+import type { EnvironmentData, Observation } from "@/lib/types/api";
+
+interface HeatmapCell {
+  row: number;
+  col: number;
+  count: number;
+  label: string;
+  temp?: number;
+  humidity?: number;
+  aqi?: number;
+}
+
+type HeatmapMode = "date-hour" | "week-day" | "month-weekday";
+
+interface HeatmapGrid {
+  cells: HeatmapCell[][];
+  rowLabels: string[];
+  colLabels: string[];
+  maxCount: number;
+  mode: HeatmapMode;
+}
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const HOUR_LABELS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0"));
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const monthDayFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+});
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+});
+
+function getStartOfDay(date: Date): Date {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+function daysBetweenInclusive(startDate: string, endDate: string): number {
+  const start = getStartOfDay(new Date(startDate)).getTime();
+  const end = getStartOfDay(new Date(endDate)).getTime();
+  return Math.max(1, Math.floor((end - start) / DAY_MS) + 1);
+}
+
+function pickHeatmapMode(rangePreset: string, startDate: string, endDate: string): HeatmapMode {
+  if (rangePreset === "24h") {
+    return "date-hour";
+  }
+
+  const totalDays = daysBetweenInclusive(startDate, endDate);
+
+  if (totalDays <= 14) {
+    return "date-hour";
+  }
+  if (totalDays <= 120) {
+    return "week-day";
+  }
+  return "month-weekday";
+}
+
+function jsDayToMondayIndex(jsDay: number): number {
+  return jsDay === 0 ? 6 : jsDay - 1;
+}
+
+function avg(values: number[]): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  return Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) / 10;
+}
+
+function filterObservations(
+  observations: Observation[],
+  minConfidence: number,
+  taxonomyLevel: TaxonomyLevel,
+): Observation[] {
+  return observations.filter((obs) => {
+    const confidence = getObservationConfidence(obs, taxonomyLevel);
+    return confidence >= minConfidence;
+  });
+}
+
+function buildEnvLookup(
+  envData: EnvironmentData[],
+  bucketKeyForDate: (date: Date) => string | null,
+): Map<string, { temps: number[]; humidities: number[]; aqis: number[] }> {
+  const lookup = new Map<string, { temps: number[]; humidities: number[]; aqis: number[] }>();
+
+  for (const item of envData) {
+    const date = new Date(item.timestamp);
+    const key = bucketKeyForDate(date);
+
+    if (!key) {
+      continue;
+    }
+
+    let bucket = lookup.get(key);
+    if (!bucket) {
+      bucket = { temps: [], humidities: [], aqis: [] };
+      lookup.set(key, bucket);
+    }
+
+    if (item.ambient_temperature !== undefined) {
+      bucket.temps.push(item.ambient_temperature);
+    }
+    if (item.ambient_humidity !== undefined) {
+      bucket.humidities.push(item.ambient_humidity);
+    }
+    if (item.voc_index !== undefined) {
+      bucket.aqis.push(item.voc_index);
+    }
+  }
+
+  return lookup;
+}
+
+function applyEnvData(
+  cells: HeatmapCell[][],
+  lookup: Map<string, { temps: number[]; humidities: number[]; aqis: number[] }>,
+) {
+  for (const row of cells) {
+    for (const cell of row) {
+      const bucket = lookup.get(`${cell.row}-${cell.col}`);
+
+      if (!bucket) {
+        continue;
+      }
+
+      cell.temp = avg(bucket.temps);
+      cell.humidity = avg(bucket.humidities);
+      cell.aqi = avg(bucket.aqis);
+    }
+  }
+}
+
+function getMaxCount(cells: HeatmapCell[][]): number {
+  let maxCount = 0;
+
+  for (const row of cells) {
+    for (const cell of row) {
+      if (cell.count > maxCount) {
+        maxCount = cell.count;
+      }
+    }
+  }
+
+  return maxCount;
+}
+
+export {
+  DAY_LABELS,
+  HOUR_LABELS,
+  applyEnvData,
+  buildEnvLookup,
+  filterObservations,
+  formatMonthKey,
+  formatDateKey,
+  getMaxCount,
+  getStartOfDay,
+  getWeekStart,
+  jsDayToMondayIndex,
+  monthDayFormatter,
+  monthFormatter,
+  pickHeatmapMode,
+};
+export type { HeatmapCell, HeatmapGrid, HeatmapMode };
+
+function formatDateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+    date.getDate(),
+  ).padStart(2, "0")}`;
+}
+
+function getWeekStart(date: Date): Date {
+  const weekStart = getStartOfDay(date);
+  const day = weekStart.getDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  weekStart.setDate(weekStart.getDate() + offset);
+  return weekStart;
+}
+
+function formatMonthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}

--- a/src/lib/hooks/useScrollDirection.ts
+++ b/src/lib/hooks/useScrollDirection.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+
+type ScrollDirection = "up" | "down" | null;
+
+const LOCK_MS = 400;
+
+function useScrollDirection() {
+  const [direction, setDirection] = useState<ScrollDirection>(null);
+  const [scrolled, setScrolled] = useState(false);
+  const lastY = useRef(0);
+  const lockedUntil = useRef(0);
+
+  useEffect(() => {
+    const el = document.querySelector("main")?.parentElement;
+    if (!el) {
+      return;
+    }
+
+    let ticking = false;
+
+    const onScroll = () => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+
+      requestAnimationFrame(() => {
+        const y = el.scrollTop;
+        const now = performance.now();
+
+        if (now > lockedUntil.current) {
+          setScrolled((prev) => {
+            const next = y > 10;
+            if (next !== prev) {
+              lockedUntil.current = now + LOCK_MS;
+            }
+            return next;
+          });
+        }
+
+        const diff = y - lastY.current;
+        if (Math.abs(diff) > 5) {
+          setDirection(diff > 0 ? "down" : "up");
+          lastY.current = y;
+        }
+
+        ticking = false;
+      });
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return { direction, scrolled };
+}
+
+export { useScrollDirection };

--- a/src/routes/deployment/$deploymentId/_filterLayout.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout.tsx
@@ -66,7 +66,7 @@ function LayoutComponent() {
         <Separator />
       </div>
 
-      <div className="flex w-full grow flex-col px-4 py-8">
+      <div className="flex w-full grow flex-col px-4 pt-12 pb-8">
         <Outlet />
       </div>
     </FilterProvider>

--- a/src/routes/deployment/$deploymentId/_filterLayout.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout.tsx
@@ -9,6 +9,7 @@ import { buttonVariants } from "@/components/ui/button-variants";
 import { Separator } from "@/components/ui/Separator";
 import { filtersDefault, filtersSchema } from "@/lib/filters";
 import { FilterProvider } from "@/lib/filters/FilterContext";
+import { useScrollDirection } from "@/lib/hooks/useScrollDirection";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/deployment/$deploymentId/_filterLayout")({
@@ -19,31 +20,45 @@ export const Route = createFileRoute("/deployment/$deploymentId/_filterLayout")(
   component: LayoutComponent,
 });
 
+function CollapsibleNav({ deploymentId }: { deploymentId: string }) {
+  return (
+    <div className="overflow-hidden">
+      <div className="flex items-center gap-3 px-6 py-3">
+        <Link
+          to="/"
+          className={cn(
+            buttonVariants({ variant: "ghost", size: "sm" }),
+            "gap-1 text-muted-foreground",
+          )}
+        >
+          <ChevronLeftIcon />
+          Deployments
+        </Link>
+        <Separator orientation="vertical" />
+        <h1 className="font-semibold">{deploymentId}</h1>
+      </div>
+      <Separator />
+      <DeploymentSelector deploymentId={deploymentId} />
+    </div>
+  );
+}
+
 function LayoutComponent() {
   const { deploymentId } = Route.useParams();
+  const { scrolled } = useScrollDirection();
 
   return (
     <FilterProvider>
-      {/* top-16.25 is a hacky fix but I don't know how else to do it - needs to be updated if header changes size */}
       <div className="sticky top-16.25 z-10 flex flex-col bg-background/90 backdrop-blur-lg">
-        {/* Not in figma, maybe remove remove? (header + filters take a lot of space) */}
-        <div className="flex items-center gap-3 px-6 py-3">
-          <Link
-            to="/"
-            className={cn(
-              buttonVariants({ variant: "ghost", size: "sm" }),
-              "gap-1 text-muted-foreground",
-            )}
-          >
-            <ChevronLeftIcon />
-            Deployments
-          </Link>
-          <Separator orientation="vertical" />
-          <h1 className="font-semibold">{deploymentId}</h1>
+        <div
+          className={cn(
+            "grid transition-[grid-template-rows,opacity] duration-300 ease-in-out",
+            scrolled ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100",
+          )}
+        >
+          <CollapsibleNav deploymentId={deploymentId} />
         </div>
 
-        <Separator />
-        <DeploymentSelector deploymentId={deploymentId} />
         <Separator />
         <FiltersRow />
         <Separator />

--- a/src/routes/deployment/$deploymentId/_filterLayout/analytics.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/analytics.tsx
@@ -5,7 +5,7 @@ import { ActivityHeatmap } from "@/components/charts/ActivityHeatmap";
 import { AirPollutionChart } from "@/components/charts/AirPollutionChart";
 import { AirQualityIndicesChart } from "@/components/charts/AirQualityIndicesChart";
 import { EnvironmentalConditionsChart } from "@/components/charts/EnvironmentalConditionsChart";
-import { aggregateHeatmap, pickHeatmapMode } from "@/lib/heatmapAggregation";
+import { aggregateHeatmap } from "@/lib/heatmapAggregation";
 import { useEnvironmentData } from "@/lib/hooks/useEnvironmentData";
 import { useFilters } from "@/lib/hooks/useFilters";
 import { useObservations } from "@/lib/hooks/useObservations";
@@ -25,7 +25,16 @@ function RouteComponent() {
     limit: 500,
   });
 
-  const envItems = useMemo(() => envResult ?? [], [envResult]);
+  const envItems = useMemo(() => {
+    const startMs = new Date(startDate).getTime();
+    const endMs = new Date(endDate).getTime();
+
+    return (envResult ?? []).filter((item) => {
+      const timestampMs = new Date(item.timestamp).getTime();
+      const matchesHub = !hub || item.device_id === hub;
+      return matchesHub && timestampMs >= startMs && timestampMs <= endMs;
+    });
+  }, [envResult, hub, startDate, endDate]);
   const obsItems = useMemo(() => obsResult?.items ?? [], [obsResult?.items]);
 
   const heatmapGrid = useMemo(
@@ -41,9 +50,6 @@ function RouteComponent() {
       ),
     [obsItems, envItems, startDate, endDate, rangePreset, minConfidence, taxonomyLevel],
   );
-
-  const heatmapMode = pickHeatmapMode(rangePreset, startDate, endDate);
-
   if (envLoading && obsLoading) {
     return <div>Loading data...</div>;
   }
@@ -55,10 +61,8 @@ function RouteComponent() {
     <div className="flex flex-col gap-6">
       <ActivityHeatmap
         grid={heatmapGrid}
-        peakIntensity={heatmapGrid.maxCount}
-        rangeLabel={heatmapMode === "day-hour" ? "day-hour" : "week-day"}
         taxonomyLabel={taxonomyLevel}
-        isLoading={obsLoading}
+        isLoading={obsLoading || envLoading}
       />
 
       <div className="flex flex-col border border-border">

--- a/src/routes/deployment/$deploymentId/_filterLayout/analytics.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/analytics.tsx
@@ -1,38 +1,80 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
 
+import { ActivityHeatmap } from "@/components/charts/ActivityHeatmap";
 import { AirPollutionChart } from "@/components/charts/AirPollutionChart";
 import { AirQualityIndicesChart } from "@/components/charts/AirQualityIndicesChart";
 import { EnvironmentalConditionsChart } from "@/components/charts/EnvironmentalConditionsChart";
+import { aggregateHeatmap, pickHeatmapMode } from "@/lib/heatmapAggregation";
 import { useEnvironmentData } from "@/lib/hooks/useEnvironmentData";
+import { useFilters } from "@/lib/hooks/useFilters";
+import { useObservations } from "@/lib/hooks/useObservations";
 
 export const Route = createFileRoute("/deployment/$deploymentId/_filterLayout/analytics")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const { isLoading, isError, error } = useEnvironmentData();
+  const { startDate, endDate, hub, rangePreset, taxonomyLevel, minConfidence } = useFilters();
 
-  if (isLoading) {
-    return <div>Loading environmental data...</div>;
+  const { data: envResult, isLoading: envLoading, isError, error } = useEnvironmentData();
+  const { data: obsResult, isLoading: obsLoading } = useObservations({
+    deviceFilter: hub,
+    startTime: startDate,
+    endTime: endDate,
+    limit: 500,
+  });
+
+  const envItems = useMemo(() => envResult ?? [], [envResult]);
+  const obsItems = useMemo(() => obsResult?.items ?? [], [obsResult?.items]);
+
+  const heatmapGrid = useMemo(
+    () =>
+      aggregateHeatmap(
+        obsItems,
+        envItems,
+        startDate,
+        endDate,
+        rangePreset,
+        minConfidence,
+        taxonomyLevel,
+      ),
+    [obsItems, envItems, startDate, endDate, rangePreset, minConfidence, taxonomyLevel],
+  );
+
+  const heatmapMode = pickHeatmapMode(rangePreset, startDate, endDate);
+
+  if (envLoading && obsLoading) {
+    return <div>Loading data...</div>;
   }
   if (isError && error) {
     return <div>Error: {error.message}</div>;
   }
 
   return (
-    <div className="flex flex-col border">
-      <h2 className="p-2 text-xl font-semibold">Environmental Data</h2>
+    <div className="flex flex-col gap-6">
+      <ActivityHeatmap
+        grid={heatmapGrid}
+        peakIntensity={heatmapGrid.maxCount}
+        rangeLabel={heatmapMode === "day-hour" ? "day-hour" : "week-day"}
+        taxonomyLabel={taxonomyLevel}
+        isLoading={obsLoading}
+      />
 
-      <div className="rounded p-4">
-        <EnvironmentalConditionsChart />
-      </div>
+      <div className="flex flex-col border border-border">
+        <h2 className="p-4 text-xl font-semibold">Environmental Data</h2>
 
-      <div className="rounded p-4">
-        <AirPollutionChart />
-      </div>
+        <div className="rounded p-4">
+          <EnvironmentalConditionsChart />
+        </div>
 
-      <div className="rounded p-4">
-        <AirQualityIndicesChart />
+        <div className="rounded p-4">
+          <AirPollutionChart />
+        </div>
+
+        <div className="rounded p-4">
+          <AirQualityIndicesChart />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #42 

Completes the activity heatmap in Analytics (needs refactor for multi-taxa filtering)

### What changed
 - Added a heatmap for detection activity in the Analytics view
 - Made it respond to global filters like date range, hub, taxonomy level, and AI confidence
 - Added adaptive layouts for short and long date ranges, including custom ranges
 - Updated the styling to match the green dashboard theme
 - Improved tooltip behavior and confidence handling
 - Show environmental data only in hour-based views
 - Refactored the implementation into smaller files for maintainability

### Notes
 - The heatmap still uses frontend aggregation for now
 - This SHOULD be extended later for multi-taxa filtering

