### PR TITLE
60 add dynamic color to confidence progress bars

### DIFF
--- a/src/components/observations/ConfidenceProgessBar.tsx
+++ b/src/components/observations/ConfidenceProgessBar.tsx
@@ -7,23 +7,21 @@ type ConfidenceProgressBarProps = {
 
 function ConfidenceProgressBar({ confidence }: ConfidenceProgressBarProps) {
   return (
-    <div className="flex flex-col md:flex-row md:items-center md:gap-4">
+    <div className="flex items-center gap-4">
       <Progress
         className={cn(
-          "md:basis-3/5",
-          confidence >= 1
-            ? "border border-green-800/50 *:data-[slot=progress-indicator]:bg-green-800"
-            : confidence >= 0.8
-              ? "border border-green-500/40 *:data-[slot=progress-indicator]:bg-green-500"
-              : confidence >= 0.6
-                ? "border border-yellow-500/40 *:data-[slot=progress-indicator]:bg-yellow-500"
-                : confidence >= 0.4
-                  ? "border border-orange-400/40 *:data-[slot=progress-indicator]:bg-orange-400"
-                  : "border border-red-700/50 *:data-[slot=progress-indicator]:bg-red-700",
+          "basis-3/5 border",
+          confidence >= 0.8
+            ? "border-success/50 *:data-[slot=progress-indicator]:bg-success"
+            : confidence >= 0.6
+              ? "border-caution/50 *:data-[slot=progress-indicator]:bg-caution"
+              : confidence >= 0.4
+                ? "border-warn/50 *:data-[slot=progress-indicator]:bg-warn"
+                : "border-destructive/50 *:data-[slot=progress-indicator]:bg-destructive",
         )}
         value={confidence * 100}
       />
-      <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
+      <span className="basis-1/5 py-2">{`${(confidence * 100).toFixed(0)}%`}</span>
     </div>
   );
 }

--- a/src/components/observations/ConfidenceProgessBar.tsx
+++ b/src/components/observations/ConfidenceProgessBar.tsx
@@ -1,0 +1,31 @@
+import { Progress } from "@/components/ui/Progress";
+import { cn } from "@/lib/utils";
+
+type ConfidenceProgressBarProps = {
+  confidence: number;
+};
+
+function ConfidenceProgressBar({ confidence }: ConfidenceProgressBarProps) {
+  return (
+    <div className="flex flex-col md:flex-row md:items-center md:gap-4">
+      <Progress
+        className={cn(
+          "md:basis-3/5",
+          confidence >= 1
+            ? "border border-green-800/50 *:data-[slot=progress-indicator]:bg-green-800"
+            : confidence >= 0.8
+              ? "border border-green-500/40 *:data-[slot=progress-indicator]:bg-green-500"
+              : confidence >= 0.6
+                ? "border border-yellow-500/40 *:data-[slot=progress-indicator]:bg-yellow-500"
+                : confidence >= 0.4
+                  ? "border border-orange-400/40 *:data-[slot=progress-indicator]:bg-orange-400"
+                  : "border border-red-700/50 *:data-[slot=progress-indicator]:bg-red-700",
+        )}
+        value={confidence * 100}
+      />
+      <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
+    </div>
+  );
+}
+
+export { ConfidenceProgressBar };

--- a/src/components/observations/columns.tsx
+++ b/src/components/observations/columns.tsx
@@ -2,17 +2,18 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDownIcon, ArrowUpIcon, ArrowDownIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
-import { Progress } from "@/components/ui/Progress";
 import type { Observation } from "@/lib/types/api";
 import { cn } from "@/lib/utils";
-/**
-* Columns: Image, Hub, Family, Genus, Species and timestamp.
-* 
-* @status - incomplete progres sbar should match confidence.
-* @todo - Edit color of progress bar to match confidence satisfaction. 
-* @todo - When confirmations status is supported in backend, implement confirmations tatus row.
 
-*/
+import { ConfidenceProgressBar } from "./ConfidenceProgessBar";
+
+/**
+ * Columns: Image, Hub, Family, Genus, Species and timestamp.
+ *
+ * @status - incomplete progres sbar should match confidence.
+ * @todo - Edit color of progress bar to match confidence satisfaction.
+ * @todo - When confirmations status is supported in backend, implement confirmations tatus row.
+ */
 
 const columns: ColumnDef<Observation>[] = [
   {
@@ -60,7 +61,6 @@ const columns: ColumnDef<Observation>[] = [
       );
     },
     sortingFn: "datetime",
-
     cell: ({ row }) => {
       const value = row.original.timestamp as string | number | Date | null;
 
@@ -102,31 +102,8 @@ const columns: ColumnDef<Observation>[] = [
   {
     accessorKey: "family_confidence",
     header: "Confidence",
-    cell: ({ row }) => {
-      const confidence = row.original.family_confidence;
-      return (
-        <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <Progress
-            className={cn(
-              "md:basis-3/5",
-              confidence >= 1
-                ? "border border-green-800/50 **:data-[slot=progress-indicator]:bg-green-800"
-                : confidence >= 0.8
-                  ? "border border-green-500/40 **:data-[slot=progress-indicator]:bg-green-500"
-                  : confidence >= 0.6
-                    ? "border border-orange-500/40 **:data-[slot=progress-indicator]:bg-orange-500"
-                    : confidence >= 0.4
-                      ? "border border-red-400/40 **:data-[slot=progress-indicator]:bg-red-400"
-                      : "border border-red-700/50 **:data-[slot=progress-indicator]:bg-red-700",
-            )}
-            value={confidence * 100}
-          />
-          <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
-        </div>
-      );
-    },
+    cell: ({ row }) => <ConfidenceProgressBar confidence={row.original.family_confidence} />,
   },
-
   {
     accessorKey: "genus",
     header: "Genus",
@@ -138,29 +115,7 @@ const columns: ColumnDef<Observation>[] = [
   {
     accessorKey: "genus_confidence",
     header: "Confidence",
-    cell: ({ row }) => {
-      const confidence = row.original.genus_confidence;
-      return (
-        <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <Progress
-            className={cn(
-              "md:basis-3/5",
-              confidence >= 1
-                ? "border border-green-800/50 **:data-[slot=progress-indicator]:bg-green-800"
-                : confidence >= 0.8
-                  ? "border border-green-500/40 **:data-[slot=progress-indicator]:bg-green-500"
-                  : confidence >= 0.6
-                    ? "border border-orange-500/40 **:data-[slot=progress-indicator]:bg-orange-500"
-                    : confidence >= 0.4
-                      ? "border border-red-400/40 **:data-[slot=progress-indicator]:bg-red-400"
-                      : "border border-red-700/50 **:data-[slot=progress-indicator]:bg-red-700",
-            )}
-            value={confidence * 100}
-          />
-          <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
-        </div>
-      );
-    },
+    cell: ({ row }) => <ConfidenceProgressBar confidence={row.original.genus_confidence} />,
   },
   {
     accessorKey: "species",
@@ -173,29 +128,8 @@ const columns: ColumnDef<Observation>[] = [
   {
     accessorKey: "species_confidence",
     header: "Confidence",
-    cell: ({ row }) => {
-      const confidence = row.original.species_confidence;
-      return (
-        <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <Progress
-            className={cn(
-              "md:basis-3/5",
-              confidence >= 1
-                ? "border border-green-800/50 **:data-[slot=progress-indicator]:bg-green-800"
-                : confidence >= 0.8
-                  ? "border border-green-500/40 **:data-[slot=progress-indicator]:bg-green-500"
-                  : confidence >= 0.6
-                    ? "border border-orange-500/40 **:data-[slot=progress-indicator]:bg-orange-500"
-                    : confidence >= 0.4
-                      ? "border border-red-400/40 **:data-[slot=progress-indicator]:bg-red-400"
-                      : "border border-red-700/50 **:data-[slot=progress-indicator]:bg-red-700",
-            )}
-            value={confidence * 100}
-          />
-          <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
-        </div>
-      );
-    },
+    cell: ({ row }) => <ConfidenceProgressBar confidence={row.original.species_confidence} />,
   },
 ];
+
 export { columns };

--- a/src/components/observations/columns.tsx
+++ b/src/components/observations/columns.tsx
@@ -9,10 +9,7 @@ import { ConfidenceProgressBar } from "./ConfidenceProgessBar";
 
 /**
  * Columns: Image, Hub, Family, Genus, Species and timestamp.
- *
- * @status - incomplete progres sbar should match confidence.
- * @todo - Edit color of progress bar to match confidence satisfaction.
- * @todo - When confirmations status is supported in backend, implement confirmations tatus row.
+ * @status - When confirmations status is supported in backend, implement confirmations tatus row.
  */
 
 const columns: ColumnDef<Observation>[] = [

--- a/src/components/observations/columns.tsx
+++ b/src/components/observations/columns.tsx
@@ -106,7 +106,21 @@ const columns: ColumnDef<Observation>[] = [
       const confidence = row.original.family_confidence;
       return (
         <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <Progress className="md:basis-3/5" value={confidence * 100} />
+          <Progress
+            className={cn(
+              "md:basis-3/5",
+              confidence >= 1
+                ? "border border-green-800/50 **:data-[slot=progress-indicator]:bg-green-800"
+                : confidence >= 0.8
+                  ? "border border-green-500/40 **:data-[slot=progress-indicator]:bg-green-500"
+                  : confidence >= 0.6
+                    ? "border border-orange-500/40 **:data-[slot=progress-indicator]:bg-orange-500"
+                    : confidence >= 0.4
+                      ? "border border-red-400/40 **:data-[slot=progress-indicator]:bg-red-400"
+                      : "border border-red-700/50 **:data-[slot=progress-indicator]:bg-red-700",
+            )}
+            value={confidence * 100}
+          />
           <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
         </div>
       );
@@ -128,7 +142,21 @@ const columns: ColumnDef<Observation>[] = [
       const confidence = row.original.genus_confidence;
       return (
         <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <Progress className="md:basis-3/5" value={confidence * 100} />
+          <Progress
+            className={cn(
+              "md:basis-3/5",
+              confidence >= 1
+                ? "border border-green-800/50 **:data-[slot=progress-indicator]:bg-green-800"
+                : confidence >= 0.8
+                  ? "border border-green-500/40 **:data-[slot=progress-indicator]:bg-green-500"
+                  : confidence >= 0.6
+                    ? "border border-orange-500/40 **:data-[slot=progress-indicator]:bg-orange-500"
+                    : confidence >= 0.4
+                      ? "border border-red-400/40 **:data-[slot=progress-indicator]:bg-red-400"
+                      : "border border-red-700/50 **:data-[slot=progress-indicator]:bg-red-700",
+            )}
+            value={confidence * 100}
+          />
           <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
         </div>
       );
@@ -149,12 +177,25 @@ const columns: ColumnDef<Observation>[] = [
       const confidence = row.original.species_confidence;
       return (
         <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <Progress className="md:basis-3/5" value={confidence * 100} />
+          <Progress
+            className={cn(
+              "md:basis-3/5",
+              confidence >= 1
+                ? "border border-green-800/50 **:data-[slot=progress-indicator]:bg-green-800"
+                : confidence >= 0.8
+                  ? "border border-green-500/40 **:data-[slot=progress-indicator]:bg-green-500"
+                  : confidence >= 0.6
+                    ? "border border-orange-500/40 **:data-[slot=progress-indicator]:bg-orange-500"
+                    : confidence >= 0.4
+                      ? "border border-red-400/40 **:data-[slot=progress-indicator]:bg-red-400"
+                      : "border border-red-700/50 **:data-[slot=progress-indicator]:bg-red-700",
+            )}
+            value={confidence * 100}
+          />
           <span className="py-2 md:basis-1/5">{`${(confidence * 100).toFixed(0)}%`}</span>
         </div>
       );
     },
   },
 ];
-
 export { columns };

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -16,7 +16,7 @@ function Progress({ className, children, value, ...props }: ProgressPrimitive.Ro
       {children}
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="size-full flex-1 bg-primary transition-all"
+        className="size-full flex-1 transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -16,7 +16,7 @@ function Progress({ className, children, value, ...props }: ProgressPrimitive.Ro
       {children}
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="size-full flex-1 transition-all"
+        className="size-full flex-1 bg-primary transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,7 @@
   --color-success: oklch(56% 0.1218 155.86);
   --color-warn: oklch(74.74% 0.1796 57.14);
   --color-destructive: oklch(57.85% 0.2138 27.17);
+  --color-caution: oklch(82.318% 0.16705 96.973);
 }
 
 @layer base {


### PR DESCRIPTION
Task description: 

Observation table contains a progress bar representing percentage of confidence. The progress bar is now always green.
The color of progress bar should match confidence satisfaction for data. e.g. green for acceptable, orange for use with caution, red for practically unusable.

Progress bar is found in columns.tsx
Progress bar uses ui component Progress.tsx


- [x] Progress bar track should have color border

What was done:


Added dynamic color to confidence progess bar. 

- Confidence =100% is dark green
- Confidence >80% is green 
- Confidence >60% is orange 
- Confidence >40% is red
- Confidence <40% is dark red




Closed https://github.com/seandreassen/sensing-garden-dashboard/issues/60

