### PR TITLE
fix: Fixed map doesnt correctly show pin for center location

### DIFF
--- a/src/components/map/GoogleMaps.tsx
+++ b/src/components/map/GoogleMaps.tsx
@@ -28,13 +28,14 @@ interface GoogleMapsProps {
 }
 
 function GoogleMaps({ deploymentId, allowDragAndDrop = false }: GoogleMapsProps) {
-  const { data } = useDeployment({ deployment_id: deploymentId });
+  const { data, isLoading } = useDeployment({ deployment_id: deploymentId });
 
   const [locations, setLocations] = useState<Location[]>([]);
   useEffect(() => {
-    setLocations(
-      data?.devices.map((device) => device.location).filter((location) => !!location) ?? [],
-    );
+    if (!data) {
+      return;
+    }
+    setLocations(data.devices.map((device) => device.location).filter((location) => !!location));
   }, [data]);
 
   return (
@@ -53,7 +54,9 @@ function GoogleMaps({ deploymentId, allowDragAndDrop = false }: GoogleMapsProps)
         </div>
       )}
       <div className="flex h-125 items-center justify-center">
-        {env.VITE_GOOGLE_MAPS_API_KEY ? (
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading map...</p>
+        ) : env.VITE_GOOGLE_MAPS_API_KEY ? (
           <APIProvider apiKey={env.VITE_GOOGLE_MAPS_API_KEY}>
             <MapWithDrop
               locations={locations}

--- a/src/components/map/MapWithDrop.tsx
+++ b/src/components/map/MapWithDrop.tsx
@@ -125,20 +125,28 @@ function MapWithDrop({ locations, setLocations, center, allowDragAndDrop }: MapW
         mapId="DEMO_MAP_ID"
         onCameraChanged={(ev) => setZoom(ev.detail.zoom)}
       >
-        {center && zoom < minZoom && (
-          <AdvancedMarker position={{ lat: center.lat, lng: center.long }}>
-            <PinIcon />
-          </AdvancedMarker>
-        )}
-        {zoom >= minZoom &&
-          locations.map((loc, i) => (
-            <AdvancedMarker
-              key={i}
-              position={{ lat: loc.lat, lng: loc.long }}
-              draggable={allowDragAndDrop}
-              onDragEnd={(e) => handleDragEnd(i, e)}
-            />
-          ))}
+        {zoom < minZoom
+          ? (() => {
+              const overviewPosition = center
+                ? { lat: center.lat, lng: center.long }
+                : locations.length > 0
+                  ? {
+                      lat: locations.reduce((sum, l) => sum + l.lat, 0) / locations.length,
+                      lng: locations.reduce((sum, l) => sum + l.long, 0) / locations.length,
+                    }
+                  : null;
+              return overviewPosition ? (
+                <AdvancedMarker position={overviewPosition}>{center && <PinIcon />}</AdvancedMarker>
+              ) : null;
+            })()
+          : locations.map((loc, i) => (
+              <AdvancedMarker
+                key={i}
+                position={{ lat: loc.lat, lng: loc.long }}
+                draggable={allowDragAndDrop}
+                onDragEnd={(e) => handleDragEnd(i, e)}
+              />
+            ))}
       </Map>
     </div>
   );

--- a/src/components/map/MapWithDrop.tsx
+++ b/src/components/map/MapWithDrop.tsx
@@ -111,6 +111,15 @@ function MapWithDrop({ locations, setLocations, center, allowDragAndDrop }: MapW
     setLocations((prev) => prev.map((loc, i) => (i === index ? { lat, long } : loc)));
   }
 
+  const overviewPosition = center
+    ? { lat: center.lat, lng: center.long }
+    : locations.length > 0
+      ? {
+          lat: locations.reduce((sum, l) => sum + l.lat, 0) / locations.length,
+          lng: locations.reduce((sum, l) => sum + l.long, 0) / locations.length,
+        }
+      : null;
+
   return (
     <div
       ref={mapDivRef}
@@ -126,19 +135,9 @@ function MapWithDrop({ locations, setLocations, center, allowDragAndDrop }: MapW
         onCameraChanged={(ev) => setZoom(ev.detail.zoom)}
       >
         {zoom < minZoom
-          ? (() => {
-              const overviewPosition = center
-                ? { lat: center.lat, lng: center.long }
-                : locations.length > 0
-                  ? {
-                      lat: locations.reduce((sum, l) => sum + l.lat, 0) / locations.length,
-                      lng: locations.reduce((sum, l) => sum + l.long, 0) / locations.length,
-                    }
-                  : null;
-              return overviewPosition ? (
-                <AdvancedMarker position={overviewPosition}>{center && <PinIcon />}</AdvancedMarker>
-              ) : null;
-            })()
+          ? overviewPosition && (
+              <AdvancedMarker position={overviewPosition}>{center && <PinIcon />}</AdvancedMarker>
+            )
           : locations.map((loc, i) => (
               <AdvancedMarker
                 key={i}


### PR DESCRIPTION
the map doesnt show the correct central pin based on the hub locations, added fix for this

The map now shows a pin for the average position of a deployments hub locations at a certain zoom level. Note, most deployments have none location for its hubs, so it shows the world map. Other hubs have wierd locations for their hubs so the average seems wierd