### PR TITLE
Enhancement/101 add error handling to observation table

### DIFF
--- a/src/components/observations/DataTable.tsx
+++ b/src/components/observations/DataTable.tsx
@@ -6,6 +6,7 @@ import {
   useReactTable,
   type OnChangeFn,
 } from "@tanstack/react-table";
+import { LoaderCircleIcon } from "lucide-react";
 import { useState, useEffect } from "react";
 
 import { ObservationRowDialog } from "@/components/observations/ObservationRowDialog";
@@ -25,9 +26,14 @@ interface DataTableProps<TData, TValue> {
   limit: number;
   data: TData[];
   nextToken?: string | null;
-  isLoading?: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string | undefined;
   sorting: SortingState;
   rowCount?: number;
+  isCountLoading: boolean;
+  isCountError: boolean;
+  countErrorMessage: string | undefined;
   pageIndex: number;
   onPageChange: (direction: "forward" | "backward") => void;
   onSortingChange: OnChangeFn<SortingState>;
@@ -37,9 +43,13 @@ interface DataTableProps<TData, TValue> {
 function DataTable<TData extends Observation, TValue>({
   columns,
   data,
+  isLoading,
+  isError,
   sorting,
   onSortingChange,
   rowCount,
+  isCountLoading,
+  isCountError,
   pageIndex,
   onPageChange,
   limit,
@@ -102,19 +112,25 @@ function DataTable<TData extends Observation, TValue>({
         variant="outline"
         size="sm"
         onClick={() => onPageChange("backward")}
-        disabled={pageIndex < 1}
+        disabled={isLoading || isError || pageIndex < 1}
       >
         Previous
       </Button>
       <div className="flex flex-col items-center text-xs">
         <p>
-          Page <span className="font-bold text-primary">{`${pageIndex + 1} `}</span>
-          of {table.getPageCount()}
+          Page{" "}
+          <span className="font-bold text-primary">{`${table.getPageCount() === 0 ? 0 : pageIndex + 1} `}</span>
+          of {isCountError ? "?" : isCountLoading ? "..." : table.getPageCount()}
         </p>
         <p>
-          Rows {pageIndex * limit + 1}-
-          {pageIndex === table.getPageCount() - 1 ? rowCount : (pageIndex + 1) * limit} of{" "}
-          {rowCount}
+          {isCountError
+            ? "Error fetching row count."
+            : isCountLoading
+              ? "Loading..."
+              : `Rows ${pageIndex * limit + 1} - 
+            ${pageIndex === table.getPageCount() - 1 ? rowCount : (pageIndex + 1) * limit}
+            of 
+            ${rowCount}`}
         </p>
       </div>
       <Button
@@ -122,7 +138,7 @@ function DataTable<TData extends Observation, TValue>({
         variant="outline"
         size="sm"
         onClick={() => onPageChange("forward")}
-        disabled={pageIndex >= table.getPageCount() - 1}
+        disabled={isLoading || isError || pageIndex >= table.getPageCount() - 1}
       >
         Next
       </Button>
@@ -152,7 +168,7 @@ function DataTable<TData extends Observation, TValue>({
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows?.length ? (
+          {!isLoading && !isError && table.getRowModel().rows?.length ? (
             table.getRowModel().rows.map((row) => (
               <TableRow
                 className="cursor-pointer text-wrap"
@@ -170,7 +186,7 @@ function DataTable<TData extends Observation, TValue>({
           ) : (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
+                {isLoading ? <LoaderCircleIcon /> : isError ? "Failed to load data" : "No results."}
               </TableCell>
             </TableRow>
           )}

--- a/src/components/observations/DataTable.tsx
+++ b/src/components/observations/DataTable.tsx
@@ -135,10 +135,10 @@ function DataTable<TData extends Observation, TValue>({
               <TableCell
                 colSpan={table.getVisibleLeafColumns().length}
                 style={{ height: `${limit * 6}rem` }}
-                className="flex h-full w-screen items-center justify-center"
+                className="flex h-full"
               >
                 {isLoading ? (
-                  <Spinner className="size-8" />
+                  <Spinner className="absolute top-1/2 left-1/2 size-8" />
                 ) : isError ? (
                   "Failed to load data"
                 ) : (

--- a/src/components/observations/DataTable.tsx
+++ b/src/components/observations/DataTable.tsx
@@ -6,11 +6,10 @@ import {
   useReactTable,
   type OnChangeFn,
 } from "@tanstack/react-table";
-//import { Spinner } from "@/components/ui/Spinner";
 import { useState, useEffect } from "react";
 
 import { ObservationRowDialog } from "@/components/observations/ObservationRowDialog";
-import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/ui/Spinner";
 import {
   Table,
   TableBody,
@@ -25,19 +24,12 @@ interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   limit: number;
   data: TData[];
-  nextToken?: string | null;
   isLoading: boolean;
   isError: boolean;
-  errorMessage: string | undefined;
   sorting: SortingState;
-  rowCount?: number;
-  isCountLoading: boolean;
-  isCountError: boolean;
-  countErrorMessage: string | undefined;
+  rowCount: number;
   pageIndex: number;
-  onPageChange: (direction: "forward" | "backward") => void;
   onSortingChange: OnChangeFn<SortingState>;
-  onLoadMore?: (nextToken: string) => void; //Not implemented function for pagination, feel free to discard.
 }
 
 function DataTable<TData extends Observation, TValue>({
@@ -48,10 +40,7 @@ function DataTable<TData extends Observation, TValue>({
   sorting,
   onSortingChange,
   rowCount,
-  isCountLoading,
-  isCountError,
   pageIndex,
-  onPageChange,
   limit,
 }: DataTableProps<TData, TValue>) {
   const { taxonomyLevel } = useFilters();
@@ -81,8 +70,8 @@ function DataTable<TData extends Observation, TValue>({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    manualPagination: true, //Shows that filtering, sorting and pagination will not be client side.
     rowCount: rowCount,
+    manualPagination: true, //Shows that filtering, sorting and pagination is done server side.
     manualSorting: true,
     manualFiltering: true,
     onSortingChange,
@@ -102,50 +91,8 @@ function DataTable<TData extends Observation, TValue>({
     setOpen(true);
   };
 
-  {
-    /*Pagination controls below. Shows what rows are shown and total rows. eg. 1-10 of 100 */
-  }
-  const paginationButtons = (
-    <div className="mb-0 flex justify-between border-t border-t-foreground bg-muted px-6 py-4">
-      <Button
-        className="w-18"
-        variant="outline"
-        size="sm"
-        onClick={() => onPageChange("backward")}
-        disabled={isLoading || isError || pageIndex < 1}
-      >
-        Previous
-      </Button>
-      <div className="flex flex-col items-center text-xs">
-        <p>
-          Page{" "}
-          <span className="font-bold text-primary">{`${table.getPageCount() === 0 ? 0 : pageIndex + 1} `}</span>
-          of {isCountError ? "?" : isCountLoading ? "..." : table.getPageCount()}
-        </p>
-        <p>
-          {isCountError
-            ? "Error fetching row count."
-            : isCountLoading
-              ? "Loading..."
-              : `Rows ${pageIndex * limit + 1} - 
-            ${pageIndex === table.getPageCount() - 1 ? rowCount : (pageIndex + 1) * limit}
-            of 
-            ${rowCount}`}
-        </p>
-      </div>
-      <Button
-        className="w-18"
-        variant="outline"
-        size="sm"
-        onClick={() => onPageChange("forward")}
-        disabled={isLoading || isError || pageIndex >= table.getPageCount() - 1}
-      >
-        Next
-      </Button>
-    </div>
-  );
   return (
-    <div className="overflow-hidden rounded-md border">
+    <>
       <ObservationRowDialog
         onClose={() => setOpen(false)}
         observationData={observationData}
@@ -188,21 +135,21 @@ function DataTable<TData extends Observation, TValue>({
               <TableCell
                 colSpan={table.getVisibleLeafColumns().length}
                 style={{ height: `${limit * 6}rem` }}
+                className="flex h-full w-screen items-center justify-center"
               >
-                <div className="flex h-full w-full items-center justify-center">
-                  {isLoading
-                    ? "..." //<Spinner/>
-                    : isError
-                      ? "Failed to load data"
-                      : "No classifications found for specified filters."}
-                </div>
+                {isLoading ? (
+                  <Spinner className="size-8" />
+                ) : isError ? (
+                  "Failed to load data"
+                ) : (
+                  "No classifications found for specified filters."
+                )}
               </TableCell>
             </TableRow>
           )}
         </TableBody>
       </Table>
-      {paginationButtons}
-    </div>
+    </>
   );
 }
 export { DataTable };

--- a/src/components/observations/DataTable.tsx
+++ b/src/components/observations/DataTable.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
   type OnChangeFn,
 } from "@tanstack/react-table";
-import { LoaderCircleIcon } from "lucide-react";
+//import { Spinner } from "@/components/ui/Spinner";
 import { useState, useEffect } from "react";
 
 import { ObservationRowDialog } from "@/components/observations/ObservationRowDialog";
@@ -106,7 +106,7 @@ function DataTable<TData extends Observation, TValue>({
     /*Pagination controls below. Shows what rows are shown and total rows. eg. 1-10 of 100 */
   }
   const paginationButtons = (
-    <div className="flex justify-between border-t border-t-foreground bg-muted px-6 py-4">
+    <div className="mb-0 flex justify-between border-t border-t-foreground bg-muted px-6 py-4">
       <Button
         className="w-18"
         variant="outline"
@@ -151,7 +151,7 @@ function DataTable<TData extends Observation, TValue>({
         observationData={observationData}
         openStatus={open}
       />
-      <Table className="w-full table-fixed text-wrap">
+      <Table className="table-fixed text-wrap">
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
@@ -185,8 +185,17 @@ function DataTable<TData extends Observation, TValue>({
             ))
           ) : (
             <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                {isLoading ? <LoaderCircleIcon /> : isError ? "Failed to load data" : "No results."}
+              <TableCell
+                colSpan={table.getVisibleLeafColumns().length}
+                style={{ height: `${limit * 6}rem` }}
+              >
+                <div className="flex h-full w-full items-center justify-center">
+                  {isLoading
+                    ? "..." //<Spinner/>
+                    : isError
+                      ? "Failed to load data"
+                      : "No classifications found for specified filters."}
+                </div>
               </TableCell>
             </TableRow>
           )}

--- a/src/components/observations/DataTable.tsx
+++ b/src/components/observations/DataTable.tsx
@@ -71,7 +71,7 @@ function DataTable<TData extends Observation, TValue>({
     columns,
     getCoreRowModel: getCoreRowModel(),
     rowCount: rowCount,
-    manualPagination: true, //Shows that filtering, sorting and pagination is done server side.
+    manualPagination: true,
     manualSorting: true,
     manualFiltering: true,
     onSortingChange,

--- a/src/components/observations/PaginationControls.tsx
+++ b/src/components/observations/PaginationControls.tsx
@@ -20,7 +20,7 @@ function PaginationControls({
   const pageCount: number = Math.ceil(rowCount / limit);
 
   return (
-    <div className="mb-0 flex justify-between border-t border-t-foreground bg-muted px-6 py-4">
+    <div className="mb-0 flex justify-center gap-6 border-t border-t-foreground bg-muted px-6 py-4">
       <Button
         className="w-18"
         variant="outline"

--- a/src/components/observations/PaginationControls.tsx
+++ b/src/components/observations/PaginationControls.tsx
@@ -1,0 +1,64 @@
+import { Button } from "@/components/ui/Button";
+
+interface PaginationControlProps {
+  isCountLoading: boolean;
+  isCountError: boolean;
+  rowCount: number;
+  pageIndex: number;
+  limit: number;
+  onPageChange: (direction: "forward" | "backward") => void;
+}
+
+function PaginationControls({
+  isCountLoading,
+  isCountError,
+  rowCount,
+  pageIndex,
+  limit,
+  onPageChange,
+}: PaginationControlProps) {
+  const pageCount: number = Math.ceil(rowCount / limit);
+
+  return (
+    <div className="mb-0 flex justify-between border-t border-t-foreground bg-muted px-6 py-4">
+      <Button
+        className="w-18"
+        variant="outline"
+        size="sm"
+        onClick={() => onPageChange("backward")}
+        disabled={pageIndex < 1}
+      >
+        Previous
+      </Button>
+      <div className="flex flex-col items-center text-xs">
+        <p>
+          Page{" "}
+          <span className="font-bold text-primary">
+            {`${pageCount === 0 ? 0 : pageIndex + 1} `}{" "}
+          </span>
+          of {isCountError ? "?" : isCountLoading ? "..." : pageCount}
+        </p>
+        <p>
+          {!isCountError && !isCountLoading
+            ? `Rows ${rowCount > 0 ? pageIndex * limit + 1 : 0} - 
+                ${pageIndex === pageCount - 1 ? rowCount : (pageIndex + 1) * limit}
+                of 
+                ${rowCount}`
+            : isCountLoading
+              ? "Loading..."
+              : "Error fetching row count."}
+        </p>
+      </div>
+      <Button
+        className="w-18"
+        variant="outline"
+        size="sm"
+        onClick={() => onPageChange("forward")}
+        disabled={pageIndex >= pageCount - 1}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}
+export { PaginationControls };

--- a/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react";
 
 import { columns } from "@/components/observations/columns";
 import { DataTable } from "@/components/observations/DataTable";
-import { Spinner } from "@/components/ui/Spinner";
 import { useFilters } from "@/lib/hooks/useFilters";
 import { useObservationCount } from "@/lib/hooks/useObservationCount";
 import { useObservations } from "@/lib/hooks/useObservations";
@@ -67,12 +66,8 @@ function RouteComponent() {
     setSorting(newSorting);
   };
 
-  return isLoading ? (
-    <div className="flex h-275 w-full items-center justify-center">
-      <Spinner className="size-8" />
-    </div>
-  ) : (
-    <div className="flex h-full w-full justify-center">
+  return (
+    <div className="flex w-full justify-center">
       {/* Table */}
       <DataTable
         columns={columns}

--- a/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
@@ -23,7 +23,7 @@ function RouteComponent() {
   const [pageIndex, setPageIndex] = useState<number>(0);
   const { deploymentId } = Route.useParams();
   const { startDate, endDate, hub, minConfidence, taxonomyLevel, selectedTaxa } = useFilters();
-  const { data, isLoading } = useObservations({
+  const { data, isLoading, isError, error } = useObservations({
     start_time: startDate,
     end_time: endDate,
     device_id: hub ? [hub] : undefined,
@@ -37,7 +37,12 @@ function RouteComponent() {
     next_token: `{"offset":${limit * pageIndex}}`,
   });
 
-  const { data: totalCount } = useObservationCount({
+  const {
+    data: totalCount,
+    isLoading: isCountLoading,
+    isError: isCountError,
+    error: countError,
+  } = useObservationCount({
     start_time: startDate,
     end_time: endDate,
     device_id: hub ? [hub] : undefined,
@@ -74,11 +79,16 @@ function RouteComponent() {
         limit={limit}
         data={data?.items ?? []}
         isLoading={isLoading}
+        isError={isError}
+        errorMessage={error?.message}
         sorting={sorting}
         onSortingChange={handleSortingChange}
         pageIndex={pageIndex}
         onPageChange={(direction) => onPageChange(direction)}
         rowCount={typeof totalCount?.count === "number" ? totalCount.count : 0}
+        isCountLoading={isCountLoading}
+        isCountError={isCountError}
+        countErrorMessage={countError?.message}
       />
     </div>
   );

--- a/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
@@ -42,7 +42,7 @@ function RouteComponent() {
   });
 
   const {
-    data: totalCount,
+    data: observationCount,
     isLoading: isCountLoading,
     isError: isCountError,
   } = useObservationCount({
@@ -80,7 +80,7 @@ function RouteComponent() {
         columns={columns}
         limit={limit}
         pageIndex={pageIndex}
-        rowCount={totalCount?.count ? totalCount.count : 0}
+        rowCount={observationCount?.count ? observationCount.count : 0}
         data={tableData?.items ?? []}
         isLoading={isTableLoading}
         isError={isTableError}
@@ -92,7 +92,7 @@ function RouteComponent() {
         isCountLoading={isCountLoading}
         pageIndex={pageIndex}
         onPageChange={(direction) => onPageChange(direction)}
-        rowCount={totalCount?.count ? totalCount.count : 0}
+        rowCount={observationCount?.count ? observationCount.count : 0}
         isCountError={isCountError}
       />
     </div>

--- a/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/observations.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 
 import { columns } from "@/components/observations/columns";
 import { DataTable } from "@/components/observations/DataTable";
+import { PaginationControls } from "@/components/observations/PaginationControls";
 import { useFilters } from "@/lib/hooks/useFilters";
 import { useObservationCount } from "@/lib/hooks/useObservationCount";
 import { useObservations } from "@/lib/hooks/useObservations";
@@ -17,12 +18,16 @@ export const Route = createFileRoute("/deployment/$deploymentId/_filterLayout/ob
 });
 
 function RouteComponent() {
-  const limit: number = 10;
+  const limit: number = 5;
   const [sorting, setSorting] = useState<SortingState>([{ id: "timestamp", desc: true }]);
   const [pageIndex, setPageIndex] = useState<number>(0);
   const { deploymentId } = Route.useParams();
   const { startDate, endDate, hub, minConfidence, taxonomyLevel, selectedTaxa } = useFilters();
-  const { data, isLoading, isError, error } = useObservations({
+  const {
+    data: tableData,
+    isLoading: isTableLoading,
+    isError: isTableError,
+  } = useObservations({
     start_time: startDate,
     end_time: endDate,
     device_id: hub ? [hub] : undefined,
@@ -40,12 +45,14 @@ function RouteComponent() {
     data: totalCount,
     isLoading: isCountLoading,
     isError: isCountError,
-    error: countError,
   } = useObservationCount({
     start_time: startDate,
     end_time: endDate,
     device_id: hub ? [hub] : undefined,
     deployment_id: deploymentId,
+    min_confidence: minConfidence,
+    taxonomy_level: taxonomyLevel,
+    selected_taxa: selectedTaxa,
   });
 
   useEffect(() => {
@@ -53,7 +60,7 @@ function RouteComponent() {
   }, [sorting, startDate, endDate, hub, minConfidence, taxonomyLevel, selectedTaxa]);
 
   const onPageChange = (direction: string) => {
-    if (direction === "forward" && data?.next_token) {
+    if (direction === "forward" && tableData?.next_token) {
       setPageIndex((i) => i + 1);
     }
     if (direction === "backward" && pageIndex >= 1) {
@@ -67,23 +74,26 @@ function RouteComponent() {
   };
 
   return (
-    <div className="flex w-full justify-center">
+    <div className="w-full overflow-hidden rounded-sm border">
       {/* Table */}
       <DataTable
         columns={columns}
         limit={limit}
-        data={data?.items ?? []}
-        isLoading={isLoading}
-        isError={isError}
-        errorMessage={error?.message}
+        pageIndex={pageIndex}
+        rowCount={totalCount?.count ? totalCount.count : 0}
+        data={tableData?.items ?? []}
+        isLoading={isTableLoading}
+        isError={isTableError}
         sorting={sorting}
         onSortingChange={handleSortingChange}
+      />
+      <PaginationControls
+        limit={limit}
+        isCountLoading={isCountLoading}
         pageIndex={pageIndex}
         onPageChange={(direction) => onPageChange(direction)}
-        rowCount={typeof totalCount?.count === "number" ? totalCount.count : 0}
-        isCountLoading={isCountLoading}
+        rowCount={totalCount?.count ? totalCount.count : 0}
         isCountError={isCountError}
-        countErrorMessage={countError?.message}
       />
     </div>
   );


### PR DESCRIPTION
Closes #101 

- Refactor: move Pagination controls out of data table and into its own component.

- Moves loading spinner to inside the table. (Previously in parent page `observations.tsx`)
- Adds error handling to show error, instead of no data if error occured. This is applied for the observation table `data-table.tsx` and to the total pages and total row stats in `PaginationControls.tsx`

-Minor style tweaks to observation table. Also set limit of rows to 5. Dont know what will be final size. Style tweaks will be continued in issue #75

Create new issue for adding title and card with observation count at top of page. To match figma model.