### PR TITLE
107 add key component tests

### DIFF
--- a/src/components/analytics/TaxaTreemapCell.tsx
+++ b/src/components/analytics/TaxaTreemapCell.tsx
@@ -4,7 +4,7 @@ interface TaxaTreemapCellPayload {
 }
 
 const TREEMAP_COLORS = ["#8adf9f", "#62cd7b", "#3db85f", "#238f47", "#1b6c37"];
-const OTHER_TREEMAP_COLOR = "#5aa06f";
+const OTHER_TREEMAP_COLOR = "#B3D86A";
 const MIN_LABEL_WIDTH = 40;
 const MIN_LABEL_HEIGHT = 30;
 const MIN_COUNT_WIDTH = 72;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as DeploymentDeploymentIdFilterLayoutIndexRouteImport } from "./r
 import { Route as DeploymentDeploymentIdFilterLayoutOverviewRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/overview";
 import { Route as DeploymentDeploymentIdFilterLayoutObservationsRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/observations";
 import { Route as DeploymentDeploymentIdFilterLayoutInfoRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/info";
+import { Route as DeploymentDeploymentIdFilterLayoutEditRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/edit";
 import { Route as DeploymentDeploymentIdFilterLayoutAnalyticsRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/analytics";
 
 const IndexRoute = IndexRouteImport.update({
@@ -59,6 +60,12 @@ const DeploymentDeploymentIdFilterLayoutInfoRoute =
     path: "/info",
     getParentRoute: () => DeploymentDeploymentIdFilterLayoutRoute,
   } as any);
+const DeploymentDeploymentIdFilterLayoutEditRoute =
+  DeploymentDeploymentIdFilterLayoutEditRouteImport.update({
+    id: "/edit",
+    path: "/edit",
+    getParentRoute: () => DeploymentDeploymentIdFilterLayoutRoute,
+  } as any);
 const DeploymentDeploymentIdFilterLayoutAnalyticsRoute =
   DeploymentDeploymentIdFilterLayoutAnalyticsRouteImport.update({
     id: "/analytics",
@@ -71,6 +78,7 @@ export interface FileRoutesByFullPath {
   "/deployment/$deploymentId/$": typeof DeploymentDeploymentIdSplatRoute;
   "/deployment/$deploymentId": typeof DeploymentDeploymentIdFilterLayoutRouteWithChildren;
   "/deployment/$deploymentId/analytics": typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  "/deployment/$deploymentId/edit": typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   "/deployment/$deploymentId/info": typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   "/deployment/$deploymentId/observations": typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   "/deployment/$deploymentId/overview": typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -80,6 +88,7 @@ export interface FileRoutesByTo {
   "/": typeof IndexRoute;
   "/deployment/$deploymentId/$": typeof DeploymentDeploymentIdSplatRoute;
   "/deployment/$deploymentId/analytics": typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  "/deployment/$deploymentId/edit": typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   "/deployment/$deploymentId/info": typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   "/deployment/$deploymentId/observations": typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   "/deployment/$deploymentId/overview": typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -91,6 +100,7 @@ export interface FileRoutesById {
   "/deployment/$deploymentId/$": typeof DeploymentDeploymentIdSplatRoute;
   "/deployment/$deploymentId/_filterLayout": typeof DeploymentDeploymentIdFilterLayoutRouteWithChildren;
   "/deployment/$deploymentId/_filterLayout/analytics": typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  "/deployment/$deploymentId/_filterLayout/edit": typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   "/deployment/$deploymentId/_filterLayout/info": typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   "/deployment/$deploymentId/_filterLayout/observations": typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   "/deployment/$deploymentId/_filterLayout/overview": typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -103,6 +113,7 @@ export interface FileRouteTypes {
     | "/deployment/$deploymentId/$"
     | "/deployment/$deploymentId"
     | "/deployment/$deploymentId/analytics"
+    | "/deployment/$deploymentId/edit"
     | "/deployment/$deploymentId/info"
     | "/deployment/$deploymentId/observations"
     | "/deployment/$deploymentId/overview"
@@ -112,6 +123,7 @@ export interface FileRouteTypes {
     | "/"
     | "/deployment/$deploymentId/$"
     | "/deployment/$deploymentId/analytics"
+    | "/deployment/$deploymentId/edit"
     | "/deployment/$deploymentId/info"
     | "/deployment/$deploymentId/observations"
     | "/deployment/$deploymentId/overview"
@@ -122,6 +134,7 @@ export interface FileRouteTypes {
     | "/deployment/$deploymentId/$"
     | "/deployment/$deploymentId/_filterLayout"
     | "/deployment/$deploymentId/_filterLayout/analytics"
+    | "/deployment/$deploymentId/_filterLayout/edit"
     | "/deployment/$deploymentId/_filterLayout/info"
     | "/deployment/$deploymentId/_filterLayout/observations"
     | "/deployment/$deploymentId/_filterLayout/overview"
@@ -185,6 +198,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof DeploymentDeploymentIdFilterLayoutInfoRouteImport;
       parentRoute: typeof DeploymentDeploymentIdFilterLayoutRoute;
     };
+    "/deployment/$deploymentId/_filterLayout/edit": {
+      id: "/deployment/$deploymentId/_filterLayout/edit";
+      path: "/edit";
+      fullPath: "/deployment/$deploymentId/edit";
+      preLoaderRoute: typeof DeploymentDeploymentIdFilterLayoutEditRouteImport;
+      parentRoute: typeof DeploymentDeploymentIdFilterLayoutRoute;
+    };
     "/deployment/$deploymentId/_filterLayout/analytics": {
       id: "/deployment/$deploymentId/_filterLayout/analytics";
       path: "/analytics";
@@ -197,6 +217,7 @@ declare module "@tanstack/react-router" {
 
 interface DeploymentDeploymentIdFilterLayoutRouteChildren {
   DeploymentDeploymentIdFilterLayoutAnalyticsRoute: typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  DeploymentDeploymentIdFilterLayoutEditRoute: typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   DeploymentDeploymentIdFilterLayoutInfoRoute: typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   DeploymentDeploymentIdFilterLayoutObservationsRoute: typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   DeploymentDeploymentIdFilterLayoutOverviewRoute: typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -207,6 +228,8 @@ const DeploymentDeploymentIdFilterLayoutRouteChildren: DeploymentDeploymentIdFil
   {
     DeploymentDeploymentIdFilterLayoutAnalyticsRoute:
       DeploymentDeploymentIdFilterLayoutAnalyticsRoute,
+    DeploymentDeploymentIdFilterLayoutEditRoute:
+      DeploymentDeploymentIdFilterLayoutEditRoute,
     DeploymentDeploymentIdFilterLayoutInfoRoute:
       DeploymentDeploymentIdFilterLayoutInfoRoute,
     DeploymentDeploymentIdFilterLayoutObservationsRoute:

--- a/tests/component/analyticsCards.test.tsx
+++ b/tests/component/analyticsCards.test.tsx
@@ -1,0 +1,205 @@
+import { renderWithRootProviders } from "@tests/render";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { ActivityHeatmapCard } from "@/components/analytics/ActivityHeatmapCard";
+import { AirPollutionCard } from "@/components/analytics/AirPollutionCard";
+import { AirQualityIndicesCard } from "@/components/analytics/AirQualityIndicesCard";
+import { EnvironmentalConditionsCard } from "@/components/analytics/EnvironmentalConditionsCard";
+import { TaxaTreemapCard } from "@/components/analytics/TaxaTreemapCard";
+
+const mocks = vi.hoisted(() => ({
+  useEnvironmentTimeSeries: vi.fn(),
+  useFilters: vi.fn(),
+  useObservationsTimeSeries: vi.fn(),
+  useTaxaCount: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/useEnvironmentTimeSeries", () => ({
+  useEnvironmentTimeSeries: mocks.useEnvironmentTimeSeries,
+}));
+
+vi.mock("@/lib/hooks/useFilters", () => ({
+  useFilters: mocks.useFilters,
+}));
+
+vi.mock("@/lib/hooks/useObservationsTimeSeries", () => ({
+  useObservationsTimeSeries: mocks.useObservationsTimeSeries,
+}));
+
+vi.mock("@/lib/hooks/useTaxaCount", () => ({
+  useTaxaCount: mocks.useTaxaCount,
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    className,
+    size: _size,
+    variant: _variant,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: ReactNode;
+    size?: string;
+    variant?: string;
+  }) => (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/Separator", () => ({
+  Separator: () => <div role="separator" />,
+}));
+
+vi.mock("@/components/ui/Tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({
+    children,
+    ...props
+  }: {
+    children?: ReactNode;
+  } & ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("recharts", () => ({
+  CartesianGrid: () => null,
+  Legend: () => null,
+  Line: () => null,
+  LineChart: ({ children }: { children?: ReactNode }) => <svg>{children}</svg>,
+  ResponsiveContainer: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  Tooltip: () => null,
+  Treemap: ({ data }: { data?: Array<{ name: string; count: number }> }) => (
+    <div data-testid="treemap">
+      {data?.map((item) => (
+        <span key={item.name}>
+          {item.name} {item.count}
+        </span>
+      ))}
+    </div>
+  ),
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.useFilters.mockReturnValue({
+    endDate: "2025-06-01T23:59:59.000Z",
+    hub: undefined,
+    minConfidence: 0,
+    rangePreset: "custom",
+    selectedTaxa: [],
+    startDate: "2025-06-01T00:00:00.000Z",
+    taxonomyLevel: "family",
+    updateFilters: vi.fn(),
+  });
+
+  mocks.useEnvironmentTimeSeries.mockReturnValue({
+    data: {
+      humidity: [54, 55],
+      interval_length: 1,
+      interval_unit: "h",
+      nox: [2, 3],
+      pm1p0: [1, 2],
+      pm2p5: [3, 4],
+      pm4p0: [5, 6],
+      pm10: [7, 8],
+      start_time: new Date("2025-06-01T00:00:00.000Z"),
+      temperature: [18, 19],
+      voc: [10, 11],
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  mocks.useObservationsTimeSeries.mockReturnValue({
+    data: {
+      counts: [0, 0, 0, 0, 0, 3],
+      interval_length: 1,
+      interval_unit: "h",
+      start_time: new Date("2025-06-01T00:00:00.000Z"),
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  mocks.useTaxaCount.mockReturnValue({
+    data: {
+      counts: [
+        { count: 20, taxa: "Vespa" },
+        { count: 10, taxa: "Chrysis" },
+      ],
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+});
+
+test("renders taxa treemap card with taxa data", async () => {
+  const { getByText } = await renderWithRootProviders(<TaxaTreemapCard deploymentId="dep-123" />);
+
+  await expect.element(getByText("Taxa treemap")).toBeInTheDocument();
+  await expect.element(getByText("Detection count by selected taxonomy level")).toBeInTheDocument();
+  await expect.element(getByText(/Vespa 20/)).toBeInTheDocument();
+});
+
+test("renders activity heatmap card with empty state", async () => {
+  mocks.useObservationsTimeSeries.mockReturnValue({
+    data: {
+      counts: [],
+      interval_length: 1,
+      interval_unit: "h",
+      start_time: new Date("2025-06-01T00:00:00.000Z"),
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  const { getByText } = await renderWithRootProviders(
+    <ActivityHeatmapCard deploymentId="dep-123" />,
+  );
+
+  await expect.element(getByText("Activity heatmap")).toBeInTheDocument();
+  await expect.element(getByText("No data for selected filters")).toBeInTheDocument();
+});
+
+test("renders environmental conditions card controls", async () => {
+  const { getByRole, getByText } = await renderWithRootProviders(
+    <EnvironmentalConditionsCard deploymentId="dep-123" />,
+  );
+
+  await expect.element(getByText("Environmental conditions")).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: /Temperature/ })).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: /Humidity/ })).toBeInTheDocument();
+});
+
+test("renders air pollution card controls", async () => {
+  const { getByRole, getByText } = await renderWithRootProviders(
+    <AirPollutionCard deploymentId="dep-123" />,
+  );
+
+  await expect.element(getByText("Air pollution")).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: /PM1.0/ })).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: /PM2.5/ })).toBeInTheDocument();
+});
+
+test("renders air quality indices card controls", async () => {
+  const { getByRole, getByText } = await renderWithRootProviders(
+    <AirQualityIndicesCard deploymentId="dep-123" />,
+  );
+
+  await expect.element(getByText("Air quality indices")).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: /VOC Index/ })).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: /NOx Index/ })).toBeInTheDocument();
+});

--- a/tests/component/deploymentEditorComponents.test.tsx
+++ b/tests/component/deploymentEditorComponents.test.tsx
@@ -1,0 +1,91 @@
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from "react";
+import { expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { EditDateRangeCard } from "@/components/deploymentEditor/EditDateRangeCard";
+import { EditDescriptionCard } from "@/components/deploymentEditor/EditDescriptionCard";
+import { EditImageCard } from "@/components/deploymentEditor/EditImageCard";
+import { EditNameCard } from "@/components/deploymentEditor/EditNameCard";
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    className,
+    size: _size,
+    variant: _variant,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: ReactNode;
+    size?: string;
+    variant?: string;
+  }) => (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/Checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    ...props
+  }: Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> & {
+    onCheckedChange?: (checked: boolean) => void;
+  }) => (
+    <input
+      {...props}
+      checked={Boolean(checked)}
+      type="checkbox"
+      onChange={(event) => onCheckedChange?.(event.currentTarget.checked)}
+    />
+  ),
+}));
+
+test("updates deployment name when edited", async () => {
+  const onChange = vi.fn();
+  const { getByRole } = await render(
+    <EditNameCard initialValue="Forest garden" onChange={onChange} />,
+  );
+
+  await getByRole("button", { name: /Forest garden/ }).click();
+  await getByRole("textbox").fill("Updated garden");
+
+  expect(onChange).toHaveBeenLastCalledWith("Updated garden");
+});
+
+test("updates deployment description when edited", async () => {
+  const onChange = vi.fn();
+  const { getByRole } = await render(
+    <EditDescriptionCard initialValue="Original description" onChange={onChange} />,
+  );
+
+  await getByRole("button", { name: /Original description/ }).click();
+  await getByRole("textbox").fill("Updated description");
+
+  expect(onChange).toHaveBeenLastCalledWith("Updated description");
+});
+
+test("updates deployment date range from form controls", async () => {
+  const onChange = vi.fn();
+  const { getByLabelText } = await render(
+    <EditDateRangeCard initialStartDate="2025-06-01" onChange={onChange} />,
+  );
+
+  await getByLabelText("Start date").fill("2025-07-01");
+  await getByLabelText("End date").click();
+
+  expect(onChange).toHaveBeenCalledWith("2025-07-01", null);
+  expect(onChange).toHaveBeenLastCalledWith("2025-07-01", "");
+});
+
+test("renders deployment image states", async () => {
+  const imageUrl = "https://example.com/deployment.jpg";
+  const { getByAltText, getByText, rerender } = await render(<EditImageCard />);
+
+  await expect.element(getByText("No image")).toBeInTheDocument();
+
+  await rerender(<EditImageCard initialUrl={imageUrl} />);
+
+  await expect.element(getByAltText("Preview")).toHaveAttribute("src", imageUrl);
+});

--- a/tests/component/infoComponents.test.tsx
+++ b/tests/component/infoComponents.test.tsx
@@ -3,6 +3,7 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { beforeEach, expect, test, vi } from "vitest";
 
 import { DeploymentInfoCard } from "@/components/info/DeploymentInfoCard";
+import { DeviceCard } from "@/components/info/DeviceCard";
 
 const mocks = vi.hoisted(() => ({
   useDeployment: vi.fn(),
@@ -72,19 +73,24 @@ beforeEach(() => {
   });
 });
 
-test("renders deployment info with connected hubs", async () => {
+test("renders deployment info details", async () => {
   const { getByText } = await renderWithRootProviders(<DeploymentInfoCard />);
 
   await expect.element(getByText("Deployment Information for: Forest garden")).toBeInTheDocument();
   await expect
     .element(getByText("A deployment used for testing insect observations."))
     .toBeInTheDocument();
+});
+
+test("renders device card with connected hubs", async () => {
+  const { getByText } = await renderWithRootProviders(<DeviceCard />);
+
   await expect.element(getByText("Connected hubs")).toBeInTheDocument();
   await expect.element(getByText("North hub")).toBeInTheDocument();
   await expect.element(getByText("Active")).toBeInTheDocument();
 });
 
-test("renders deployment info empty devices state", async () => {
+test("renders deployment info empty description state", async () => {
   mocks.useDeployment.mockReturnValue({
     data: {
       deployment: {
@@ -103,6 +109,26 @@ test("renders deployment info empty devices state", async () => {
   const { getByText } = await renderWithRootProviders(<DeploymentInfoCard />);
 
   await expect.element(getByText("This deployment has no description")).toBeInTheDocument();
+});
+
+test("renders device card empty devices state", async () => {
+  mocks.useDeployment.mockReturnValue({
+    data: {
+      deployment: {
+        deployment_id: "dep-123",
+        description: "",
+        name: "Forest garden",
+        start_time: new Date("2025-06-01T00:00:00.000Z"),
+      },
+      devices: [],
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  const { getByText } = await renderWithRootProviders(<DeviceCard />);
+
   await expect.element(getByText("This deployment has no connected hubs")).toBeInTheDocument();
 });
 

--- a/tests/component/infoComponents.test.tsx
+++ b/tests/component/infoComponents.test.tsx
@@ -1,0 +1,133 @@
+import { renderWithRootProviders } from "@tests/render";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { DeploymentInfoCard } from "@/components/info/DeploymentInfoCard";
+
+const mocks = vi.hoisted(() => ({
+  useDeployment: vi.fn(),
+  useObservations: vi.fn(),
+  useParams: vi.fn(),
+}));
+
+vi.mock("@/routes/deployment/$deploymentId/_filterLayout", () => ({
+  Route: {
+    useParams: mocks.useParams,
+  },
+}));
+
+vi.mock("@/lib/hooks/useDeployment", () => ({
+  useDeployment: mocks.useDeployment,
+}));
+
+vi.mock("@/lib/hooks/useObservations", () => ({
+  useObservations: mocks.useObservations,
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    className,
+    size: _size,
+    variant: _variant,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: ReactNode;
+    size?: string;
+    variant?: string;
+  }) => (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/Separator", () => ({
+  Separator: () => <div role="separator" />,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.useParams.mockReturnValue({ deploymentId: "dep-123" });
+  mocks.useObservations.mockReturnValue({
+    data: { count: 1, items: [] },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+  mocks.useDeployment.mockReturnValue({
+    data: {
+      deployment: {
+        deployment_id: "dep-123",
+        description: "A deployment used for testing insect observations.",
+        name: "Forest garden",
+        start_time: new Date("2025-06-01T00:00:00.000Z"),
+      },
+      devices: [{ deployment_id: "dep-123", device_id: "hub-1", name: "North hub" }],
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+});
+
+test("renders deployment info with connected hubs", async () => {
+  const { getByText } = await renderWithRootProviders(<DeploymentInfoCard />);
+
+  await expect.element(getByText("Deployment Information for: Forest garden")).toBeInTheDocument();
+  await expect
+    .element(getByText("A deployment used for testing insect observations."))
+    .toBeInTheDocument();
+  await expect.element(getByText("Connected hubs")).toBeInTheDocument();
+  await expect.element(getByText("North hub")).toBeInTheDocument();
+  await expect.element(getByText("Active")).toBeInTheDocument();
+});
+
+test("renders deployment info empty devices state", async () => {
+  mocks.useDeployment.mockReturnValue({
+    data: {
+      deployment: {
+        deployment_id: "dep-123",
+        description: "",
+        name: "Forest garden",
+        start_time: new Date("2025-06-01T00:00:00.000Z"),
+      },
+      devices: [],
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  const { getByText } = await renderWithRootProviders(<DeploymentInfoCard />);
+
+  await expect.element(getByText("This deployment has no description")).toBeInTheDocument();
+  await expect.element(getByText("This deployment has no connected hubs")).toBeInTheDocument();
+});
+
+test("renders deployment info loading state", async () => {
+  mocks.useDeployment.mockReturnValue({
+    data: undefined,
+    error: null,
+    isError: false,
+    isLoading: true,
+  });
+
+  const { getByText } = await renderWithRootProviders(<DeploymentInfoCard />);
+
+  await expect.element(getByText("Loading...")).toBeInTheDocument();
+});
+
+test("renders deployment info error state", async () => {
+  mocks.useDeployment.mockReturnValue({
+    data: undefined,
+    error: new Error("Could not load deployment"),
+    isError: true,
+    isLoading: false,
+  });
+
+  const { getByText } = await renderWithRootProviders(<DeploymentInfoCard />);
+
+  await expect.element(getByText("Error: Could not load deployment")).toBeInTheDocument();
+});

--- a/tests/component/landingPageComponents.test.tsx
+++ b/tests/component/landingPageComponents.test.tsx
@@ -1,0 +1,58 @@
+import { expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { DeploymentCard } from "@/components/landingPage/DeploymentCard";
+import type { Deployment } from "@/lib/types/api";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    className,
+    params,
+    to,
+  }: {
+    children?: React.ReactNode;
+    className?: string;
+    params?: { deploymentId: string };
+    to: string;
+  }) => (
+    <a className={className} href={to.replace("$deploymentId", params?.deploymentId ?? "")}>
+      {children}
+    </a>
+  ),
+}));
+
+function createDeployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    deployment_id: "dep-123",
+    description: "Forest deployment",
+    end_time: undefined,
+    location_name: "Trondheim",
+    name: "Forest garden",
+    start_time: new Date("2025-06-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+test("renders active deployment card details", async () => {
+  const { getByText } = await render(<DeploymentCard deployment={createDeployment()} />);
+
+  await expect.element(getByText("Forest garden")).toBeInTheDocument();
+  await expect.element(getByText("Trondheim")).toBeInTheDocument();
+  await expect.element(getByText("dep-123")).toBeInTheDocument();
+  await expect.element(getByText("Active")).toBeInTheDocument();
+});
+
+test("renders inactive deployment card status", async () => {
+  const { getByText } = await render(
+    <DeploymentCard
+      deployment={createDeployment({
+        end_time: new Date("2025-01-01T00:00:00.000Z"),
+        name: "Archived garden",
+      })}
+    />,
+  );
+
+  await expect.element(getByText("Archived garden")).toBeInTheDocument();
+  await expect.element(getByText("Inactive")).toBeInTheDocument();
+});

--- a/tests/component/observationsComponents.test.tsx
+++ b/tests/component/observationsComponents.test.tsx
@@ -1,0 +1,77 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { PaginationControls } from "@/components/observations/PaginationControls";
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    className,
+    size: _size,
+    variant: _variant,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: ReactNode;
+    size?: string;
+    variant?: string;
+  }) => (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+test("renders pagination state and disables previous on first page", async () => {
+  const onPageChange = vi.fn();
+  const { getByRole, getByText } = await render(
+    <PaginationControls
+      isCountError={false}
+      isCountLoading={false}
+      limit={10}
+      onPageChange={onPageChange}
+      pageIndex={0}
+      rowCount={25}
+    />,
+  );
+
+  await expect.element(getByText(/Page\s+1\s+of 3/)).toBeInTheDocument();
+  await expect.element(getByText(/Rows\s+1\s+-\s+10\s+of\s+25/)).toBeInTheDocument();
+  await expect.element(getByRole("button", { name: "Previous" })).toBeDisabled();
+  await expect.element(getByRole("button", { name: "Next" })).not.toBeDisabled();
+
+  await getByRole("button", { name: "Next" }).click();
+
+  expect(onPageChange).toHaveBeenCalledWith("forward");
+});
+
+test("renders pagination loading and error states", async () => {
+  const onPageChange = vi.fn();
+  const { getByText, rerender } = await render(
+    <PaginationControls
+      isCountError={false}
+      isCountLoading
+      limit={10}
+      onPageChange={onPageChange}
+      pageIndex={0}
+      rowCount={0}
+    />,
+  );
+
+  await expect.element(getByText(/Page\s+0\s+of \.\.\./)).toBeInTheDocument();
+  await expect.element(getByText("Loading...")).toBeInTheDocument();
+
+  await rerender(
+    <PaginationControls
+      isCountError
+      isCountLoading={false}
+      limit={10}
+      onPageChange={onPageChange}
+      pageIndex={0}
+      rowCount={0}
+    />,
+  );
+
+  await expect.element(getByText(/Page\s+0\s+of \?/)).toBeInTheDocument();
+  await expect.element(getByText("Error fetching row count.")).toBeInTheDocument();
+});

--- a/tests/component/overviewCards.test.tsx
+++ b/tests/component/overviewCards.test.tsx
@@ -1,0 +1,141 @@
+import { renderWithRootProviders } from "@tests/render";
+import type { ReactNode } from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { ObservationsCard } from "@/components/overview/ObservationsCard";
+import { SpeciesRichnessCard } from "@/components/overview/SpeciesRichnessCard";
+import { TopTaxaCard } from "@/components/overview/TopTaxaCard";
+import { TotalInsectCountCard } from "@/components/overview/TotalInsectCountCard";
+
+const mocks = vi.hoisted(() => ({
+  useFilters: vi.fn(),
+  useObservationCount: vi.fn(),
+  useObservationsTimeSeries: vi.fn(),
+  useTaxaCount: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/useFilters", () => ({
+  useFilters: mocks.useFilters,
+}));
+
+vi.mock("@/lib/hooks/useObservationCount", () => ({
+  useObservationCount: mocks.useObservationCount,
+}));
+
+vi.mock("@/lib/hooks/useObservationsTimeSeries", () => ({
+  useObservationsTimeSeries: mocks.useObservationsTimeSeries,
+}));
+
+vi.mock("@/lib/hooks/useTaxaCount", () => ({
+  useTaxaCount: mocks.useTaxaCount,
+}));
+
+vi.mock("@/components/ui/Progress", () => ({
+  Progress: ({ value }: { value?: number }) => (
+    <div aria-valuenow={value ?? 0} role="progressbar" />
+  ),
+}));
+
+vi.mock("@/components/ui/Separator", () => ({
+  Separator: () => <div role="separator" />,
+}));
+
+vi.mock("recharts", () => ({
+  Area: () => null,
+  AreaChart: ({ children }: { children?: ReactNode }) => <svg>{children}</svg>,
+  CartesianGrid: () => null,
+  ResponsiveContainer: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+function mockDefaultFilters(taxonomyLevel: "family" | "genus" | "species" = "family") {
+  mocks.useFilters.mockReturnValue({
+    endDate: "2025-06-01T23:59:59.000Z",
+    hub: undefined,
+    minConfidence: 0,
+    rangePreset: "custom",
+    selectedTaxa: [],
+    startDate: "2025-06-01T00:00:00.000Z",
+    taxonomyLevel,
+    updateFilters: vi.fn(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDefaultFilters();
+
+  mocks.useObservationCount.mockReturnValue({
+    data: { count: 100 },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  mocks.useObservationsTimeSeries.mockReturnValue({
+    data: {
+      counts: [0, 0, 0, 0, 0, 3],
+      interval_length: 1,
+      interval_unit: "h",
+      start_time: new Date("2025-06-01T00:00:00.000Z"),
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+
+  mocks.useTaxaCount.mockReturnValue({
+    data: {
+      counts: [
+        { count: 20, taxa: "Vespa" },
+        { count: 10, taxa: "Chrysis" },
+      ],
+    },
+    error: null,
+    isError: false,
+    isLoading: false,
+  });
+});
+
+test("renders observations card with chart data", async () => {
+  const { getByText } = await renderWithRootProviders(<ObservationsCard deploymentId="dep-123" />);
+
+  await expect.element(getByText("Insect detections over time")).toBeInTheDocument();
+  await expect
+    .element(getByText("Daily detection count over the selected period"))
+    .toBeInTheDocument();
+});
+
+test("renders top taxa card using selected taxonomy level", async () => {
+  mockDefaultFilters("genus");
+
+  const { getByText } = await renderWithRootProviders(<TopTaxaCard deploymentId="dep-123" />);
+
+  await expect.element(getByText("Top genera")).toBeInTheDocument();
+  await expect.element(getByText("Vespa")).toBeInTheDocument();
+  await expect.element(getByText("(20.0%)")).toBeInTheDocument();
+});
+
+test("renders species richness card using selected taxonomy level", async () => {
+  mockDefaultFilters("species");
+
+  const { getByText } = await renderWithRootProviders(
+    <SpeciesRichnessCard deploymentId="dep-123" />,
+  );
+
+  await expect.element(getByText("Unique species")).toBeInTheDocument();
+  await expect.element(getByText("2")).toBeInTheDocument();
+});
+
+test("renders total observations card with observation count", async () => {
+  const { getByText } = await renderWithRootProviders(
+    <TotalInsectCountCard deploymentId="dep-123" />,
+  );
+
+  await expect.element(getByText("Total observations")).toBeInTheDocument();
+  await expect.element(getByText("100")).toBeInTheDocument();
+});

--- a/tests/unit/location.test.ts
+++ b/tests/unit/location.test.ts
@@ -6,48 +6,48 @@ test("returns default zoom 8 for empty locations array", () => {
   expect(computeMinZoomForLocations([])).toBe(8);
 });
 
-test("returns max zoom 18 for a single location (zero spread)", () => {
-  expect(computeMinZoomForLocations([{ lat: 0, long: 0 }])).toBe(18);
+test("returns zoom 14 for a single location (zero spread)", () => {
+  expect(computeMinZoomForLocations([{ lat: 0, long: 0 }])).toBe(14);
 });
 
-test("returns zoom 18 for very tight cluster (< 100m spread)", () => {
+test("returns zoom 14 for very tight cluster (< 100m spread)", () => {
   const locations = [
     { lat: 0, long: 0 },
     { lat: 0.0004, long: 0 },
   ];
-  expect(computeMinZoomForLocations(locations)).toBe(18);
+  expect(computeMinZoomForLocations(locations)).toBe(14);
 });
 
-test("returns zoom 17 for cluster with ~200m spread", () => {
+test("returns zoom 13 for cluster with ~200m spread", () => {
   const locations = [
     { lat: 0, long: 0 },
     { lat: 0.0018, long: 0 },
   ];
-  expect(computeMinZoomForLocations(locations)).toBe(17);
+  expect(computeMinZoomForLocations(locations)).toBe(13);
 });
 
-test("returns zoom 16 for cluster with ~400m spread", () => {
+test("returns zoom 12 for cluster with ~400m spread", () => {
   const locations = [
     { lat: 0, long: 0 },
     { lat: 0.0072, long: 0 },
   ];
-  expect(computeMinZoomForLocations(locations)).toBe(16);
+  expect(computeMinZoomForLocations(locations)).toBe(12);
 });
 
-test("returns zoom 14 for cluster with ~700m spread", () => {
+test("returns zoom 10 for cluster with ~700m spread", () => {
   const locations = [
     { lat: 0, long: 0 },
     { lat: 0.0126, long: 0 },
   ];
-  expect(computeMinZoomForLocations(locations)).toBe(14);
+  expect(computeMinZoomForLocations(locations)).toBe(10);
 });
 
-test("returns zoom 12 for widely spread locations (> 1km)", () => {
+test("returns zoom 8 for widely spread locations (> 1km)", () => {
   const locations = [
     { lat: 0, long: 0 },
     { lat: 0.05, long: 0 },
   ];
-  expect(computeMinZoomForLocations(locations)).toBe(12);
+  expect(computeMinZoomForLocations(locations)).toBe(8);
 });
 
 test("handles locations far apart", () => {
@@ -55,10 +55,10 @@ test("handles locations far apart", () => {
     { lat: 10, long: 10 },
     { lat: -10, long: -10 },
   ];
-  expect(computeMinZoomForLocations(locations)).toBe(12);
+  expect(computeMinZoomForLocations(locations)).toBe(8);
 });
 
 test("handles identical locations as tight cluster", () => {
   const point = { lat: 0, long: 0 };
-  expect(computeMinZoomForLocations([point, point, point])).toBe(18);
+  expect(computeMinZoomForLocations([point, point, point])).toBe(14);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: ["@base-ui/react/button", "@base-ui/react/checkbox", "@base-ui/react/progress"],
+  },
   test: {
     include: ["tests/**/*.test.{ts,tsx}"],
     exclude: ["tests/e2e/**/*.test.{ts,tsx}"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
-    include: ["@base-ui/react/button", "@base-ui/react/checkbox", "@base-ui/react/progress"],
+    include: [
+      "@base-ui/react/button",
+      "@base-ui/react/checkbox",
+      "@base-ui/react/progress",
+      "date-fns/subWeeks",
+    ],
   },
   test: {
     include: ["tests/**/*.test.{ts,tsx}"],


### PR DESCRIPTION
Closes #107 

Added initial component tests for key top-level components across analytics, overview, landing page, info, deployment editor, and observations pagination. The scope stays at component level only, without testing pages directly outside e2e.

Also updated the stale location unit test to match current zoom threshold behavior and added a small Vitest optimizeDeps fix to avoid browser test reload flakiness.

Notes
- Mocks are kept local in the test files for now because shared imported mocks caused unstable behavior with Vitest hoisting
- Loading/error states were added where the top-level component clearly owns that state, while most other tests stay at smoke/state level for this first PR
- Heavier areas like full table behavior, Google Maps interactions, and chart internals are intentionally left for later if needed