### PR TITLE
Input validation deployment creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "date-fns": "^4.1.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.574.0",
+    "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-image-gallery": "^2.1.2",
     "recharts": "^3.8.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       lucide-react:
         specifier: ^0.574.0
         version: 0.574.0(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -56,6 +59,9 @@ importers:
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1848,6 +1854,12 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
@@ -2111,6 +2123,12 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3843,6 +3861,11 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
@@ -4142,6 +4165,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/components/deploymentEditor/EditDateRangeCard.tsx
+++ b/src/components/deploymentEditor/EditDateRangeCard.tsx
@@ -59,6 +59,7 @@ function EditDateRangeCard({
           <Input
             id="start-date"
             type="date"
+            required
             value={startDate}
             onChange={handleStartChange}
             className={inputClass}

--- a/src/components/deploymentEditor/EditImageCard.tsx
+++ b/src/components/deploymentEditor/EditImageCard.tsx
@@ -1,8 +1,8 @@
 import { PencilIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import { Card, CardTitle } from "@/components/ui/Card";
-
 function EditImageCard({
   initialUrl = "",
   onChange,
@@ -10,6 +10,17 @@ function EditImageCard({
   initialUrl?: string;
   onChange?: (value: string) => void;
 }) {
+  const MAX_IMAGE_SIZE = 100 * 1024 * 1024; // 100MB
+  const ACCEPTED_IMAGE_TYPES = [
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+    "image/svg+xml",
+    "image/bmp",
+    "image/tiff",
+  ];
   const [src, setSrc] = useState<string>(initialUrl);
   const isDirty: boolean = src !== initialUrl;
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -21,6 +32,20 @@ function EditImageCard({
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) {
+      return;
+    }
+    if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+      toast.warning("Invalid file type", {
+        description: `Accepted: ${ACCEPTED_IMAGE_TYPES.map((t) => t.split("/")[1]).join(", ")}`,
+        position: "top-center",
+      });
+      return;
+    }
+    if (file.size > MAX_IMAGE_SIZE) {
+      toast.warning("File too large", {
+        description: "Image must be under 100MB",
+        position: "top-center",
+      });
       return;
     }
     const reader = new FileReader();

--- a/src/components/deploymentEditor/EditNameCard.tsx
+++ b/src/components/deploymentEditor/EditNameCard.tsx
@@ -33,7 +33,11 @@ function EditNameCard({
       }}
       onBlur={() => {
         setIsEditing(false);
-        setValue(value);
+        if (!value) {
+          setValue(initialValue);
+        } else {
+          setValue(value);
+        }
       }}
       onKeyDown={(e) => e.key === "Enter" && setIsEditing(false)}
       className="w-full border-none bg-accent px-2 py-0 text-center outline-none"

--- a/src/components/deploymentEditor/EditNameCard.tsx
+++ b/src/components/deploymentEditor/EditNameCard.tsx
@@ -31,7 +31,10 @@ function EditNameCard({
         setValue(e.target.value);
         onChange?.(e.target.value);
       }}
-      onBlur={() => setIsEditing(false)}
+      onBlur={() => {
+        setIsEditing(false);
+        setValue(value);
+      }}
       onKeyDown={(e) => e.key === "Enter" && setIsEditing(false)}
       className="w-full border-none bg-accent px-2 py-0 text-center outline-none"
     />
@@ -41,7 +44,7 @@ function EditNameCard({
       variant="outline"
       onClick={() => setIsEditing(true)}
     >
-      {value || "Click to edit"}
+      {value || initialValue}
       <PencilIcon />
     </Button>
   );

--- a/src/components/observations/columns.tsx
+++ b/src/components/observations/columns.tsx
@@ -109,7 +109,7 @@ const columns: ColumnDef<Observation>[] = [
   },
   {
     accessorKey: "genus",
-    header: "Genus",
+    header: "GENUS",
     cell: ({ row }) => {
       const genus = row.original.genus;
       return <p className="text-wrap wrap-break-word">{genus}</p>;
@@ -122,7 +122,7 @@ const columns: ColumnDef<Observation>[] = [
   },
   {
     accessorKey: "species",
-    header: "CONFIDENCE",
+    header: "SPECIES",
     cell: ({ row }) => {
       const species = row.original.species;
       return <p className="text-wrap wrap-break-word">{species}</p>;

--- a/src/components/ui/Sonner.tsx
+++ b/src/components/ui/Sonner.tsx
@@ -18,10 +18,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       icons={{
-        success: <CircleCheckIcon className="size-4" />,
+        success: <CircleCheckIcon className="size-4 text-success" />,
         info: <InfoIcon className="size-4" />,
-        warning: <TriangleAlertIcon color="orange" className="size-4" />,
-        error: <OctagonXIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4 text-warn" />,
+        error: <OctagonXIcon color="red" className="size-4 text-destructive" />,
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       style={
@@ -29,11 +29,23 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-bg": "var(--color-popover)",
           "--normal-text": "var(--foreground)",
           "--normal-border": "var(--color-muted-foreground)",
+          "--error-bg": "var(--color-popover)",
+          "--error-text": "var(--foreground)",
+          "--error-border": "var(--destructive)",
+          "--warning-bg": "var(--color-popover)",
+          "--warning-text": "var(--foreground)",
+          "--warning-border": "var(--caution)",
+          "--success-bg": "var(--color-popover)",
+          "--success-text": "var(--foreground)",
+          "--success-border": "green",
         } as React.CSSProperties
       }
       toastOptions={{
         classNames: {
           toast: "cn-toast",
+          error: "!border-red-500",
+          warning: "!border-orange-500",
+          success: "!border-green-500",
         },
       }}
       {...props}

--- a/src/components/ui/Sonner.tsx
+++ b/src/components/ui/Sonner.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon color="orange" className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--color-popover)",
+          "--normal-text": "var(--foreground)",
+          "--normal-border": "var(--color-muted-foreground)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/src/lib/hooks/useDeploymentMutations.ts
+++ b/src/lib/hooks/useDeploymentMutations.ts
@@ -150,7 +150,7 @@ interface SaveDeploymentArgs {
   startDate?: string;
   endDate?: string | null;
   image?: string;
-  devices: Array<{ device_id: string; name?: string; location?: { lat: number; long: number } }>;
+  devices: DeploymentDevice[];
   initialDevices: Array<{
     device_id: string;
     name?: string;
@@ -181,13 +181,12 @@ function useDeploymentMutations(deploymentId: string) {
       if (startDate !== undefined) {
         deploymentPatch.start_time = startDate;
       }
-      if (endDate !== null) {
+      if (endDate !== undefined) {
         deploymentPatch.end_time = endDate;
       }
       if (image !== undefined) {
         deploymentPatch.image = image.includes(",") ? image.split(",")[1] : image;
       }
-
       const ops: Promise<unknown>[] = [];
 
       if (Object.keys(deploymentPatch).length > 0) {
@@ -250,7 +249,6 @@ function useDeploymentMutations(deploymentId: string) {
           );
         }
       }
-
       await Promise.all(ops);
     },
     onSuccess: () => {

--- a/src/lib/hooks/useDeploymentMutations.ts
+++ b/src/lib/hooks/useDeploymentMutations.ts
@@ -181,7 +181,7 @@ function useDeploymentMutations(deploymentId: string) {
       if (startDate !== undefined) {
         deploymentPatch.start_time = startDate;
       }
-      if (endDate !== undefined) {
+      if (endDate !== null) {
         deploymentPatch.end_time = endDate;
       }
       if (image !== undefined) {

--- a/src/lib/hooks/useDeploymentMutations.ts
+++ b/src/lib/hooks/useDeploymentMutations.ts
@@ -6,7 +6,6 @@ import type {
   CreateDeploymentBody,
   UpdateDeploymentBody,
   SaveDeploymentArgs,
-  DeploymentDevice,
 } from "@/lib/types/api";
 import { getHeaders } from "@/lib/utils/headers";
 
@@ -70,25 +69,18 @@ function useDeleteDeployment() {
   });
 }
 
-// --- Combined save hook for the edit page ---
-
-interface SaveDeploymentArgs {
-  name?: string;
-  description?: string;
-  startDate?: string;
-  endDate?: string | null;
-  image?: string;
-  devices: DeploymentDevice[];
-  initialDevices: Array<{
-    device_id: string;
-    name?: string;
-    location?: { lat: number; long: number };
-  }>;
+async function pushFetch(url: string, options: RequestInit, label?: string) {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message =
+      body?.message ?? body?.error ?? `${label ?? options.method} failed: ${res.status}`;
+    throw new Error(message);
+  }
+  return res;
 }
-
 function useDeploymentMutations(deploymentId: string) {
   const queryClient = useQueryClient();
-
   const mutation = useMutation({
     mutationFn: async ({
       name,
@@ -120,11 +112,15 @@ function useDeploymentMutations(deploymentId: string) {
 
       if (Object.keys(deploymentPatch).length > 0) {
         mutationRequests.push(
-          fetch(`${env.VITE_API_BASE_URL}/deployments/${deploymentId}`, {
-            method: "PATCH",
-            headers: JSON_HEADERS,
-            body: JSON.stringify(deploymentPatch),
-          }),
+          pushFetch(
+            `${env.VITE_API_BASE_URL}/deployments/${deploymentId}`,
+            {
+              method: "PATCH",
+              headers: JSON_HEADERS,
+              body: JSON.stringify(deploymentPatch),
+            },
+            "Update deployment",
+          ),
         );
       }
 
@@ -134,15 +130,19 @@ function useDeploymentMutations(deploymentId: string) {
       for (const device of devices) {
         if (!initialIds.has(device.device_id)) {
           mutationRequests.push(
-            fetch(`${env.VITE_API_BASE_URL}/deployments/${deploymentId}/devices`, {
-              method: "POST",
-              headers: JSON_HEADERS,
-              body: JSON.stringify({
-                device_id: device.device_id,
-                name: device.name,
-                location: device.location,
-              }),
-            }),
+            pushFetch(
+              `${env.VITE_API_BASE_URL}/deployments/${deploymentId}/devices`,
+              {
+                method: "POST",
+                headers: JSON_HEADERS,
+                body: JSON.stringify({
+                  device_id: device.device_id,
+                  name: device.name,
+                  location: device.location,
+                }),
+              },
+              "Add devices",
+            ),
           );
         } else {
           const initial = initialDevices.find((d) => d.device_id === device.device_id);
@@ -152,13 +152,14 @@ function useDeploymentMutations(deploymentId: string) {
               JSON.stringify(device.location) !== JSON.stringify(initial.location))
           ) {
             mutationRequests.push(
-              fetch(
+              pushFetch(
                 `${env.VITE_API_BASE_URL}/deployments/${deploymentId}/devices/${device.device_id}`,
                 {
                   method: "PATCH",
                   headers: JSON_HEADERS,
                   body: JSON.stringify({ name: device.name, location: device.location }),
                 },
+                "Update devices",
               ),
             );
           }
@@ -168,12 +169,13 @@ function useDeploymentMutations(deploymentId: string) {
       for (const initial of initialDevices) {
         if (!currentIds.has(initial.device_id)) {
           mutationRequests.push(
-            fetch(
+            pushFetch(
               `${env.VITE_API_BASE_URL}/deployments/${deploymentId}/devices/${initial.device_id}`,
               {
                 method: "DELETE",
                 headers: getHeaders(),
               },
+              "Remove devices",
             ),
           );
         }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 
+import { Toaster } from "@/components/ui/Sonner";
+
 import { routeTree } from "./routeTree.gen";
 
 import "./index.css";
@@ -39,6 +41,7 @@ if (!rootElement.innerHTML) {
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
       </QueryClientProvider>
+      <Toaster />
     </StrictMode>,
   );
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as DeploymentDeploymentIdFilterLayoutIndexRouteImport } from "./r
 import { Route as DeploymentDeploymentIdFilterLayoutOverviewRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/overview";
 import { Route as DeploymentDeploymentIdFilterLayoutObservationsRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/observations";
 import { Route as DeploymentDeploymentIdFilterLayoutInfoRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/info";
+import { Route as DeploymentDeploymentIdFilterLayoutEditRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/edit";
 import { Route as DeploymentDeploymentIdFilterLayoutAnalyticsRouteImport } from "./routes/deployment/$deploymentId/_filterLayout/analytics";
 
 const IndexRoute = IndexRouteImport.update({
@@ -59,6 +60,12 @@ const DeploymentDeploymentIdFilterLayoutInfoRoute =
     path: "/info",
     getParentRoute: () => DeploymentDeploymentIdFilterLayoutRoute,
   } as any);
+const DeploymentDeploymentIdFilterLayoutEditRoute =
+  DeploymentDeploymentIdFilterLayoutEditRouteImport.update({
+    id: "/edit",
+    path: "/edit",
+    getParentRoute: () => DeploymentDeploymentIdFilterLayoutRoute,
+  } as any);
 const DeploymentDeploymentIdFilterLayoutAnalyticsRoute =
   DeploymentDeploymentIdFilterLayoutAnalyticsRouteImport.update({
     id: "/analytics",
@@ -71,6 +78,7 @@ export interface FileRoutesByFullPath {
   "/deployment/$deploymentId/$": typeof DeploymentDeploymentIdSplatRoute;
   "/deployment/$deploymentId": typeof DeploymentDeploymentIdFilterLayoutRouteWithChildren;
   "/deployment/$deploymentId/analytics": typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  "/deployment/$deploymentId/edit": typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   "/deployment/$deploymentId/info": typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   "/deployment/$deploymentId/observations": typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   "/deployment/$deploymentId/overview": typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -80,6 +88,7 @@ export interface FileRoutesByTo {
   "/": typeof IndexRoute;
   "/deployment/$deploymentId/$": typeof DeploymentDeploymentIdSplatRoute;
   "/deployment/$deploymentId/analytics": typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  "/deployment/$deploymentId/edit": typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   "/deployment/$deploymentId/info": typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   "/deployment/$deploymentId/observations": typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   "/deployment/$deploymentId/overview": typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -91,6 +100,7 @@ export interface FileRoutesById {
   "/deployment/$deploymentId/$": typeof DeploymentDeploymentIdSplatRoute;
   "/deployment/$deploymentId/_filterLayout": typeof DeploymentDeploymentIdFilterLayoutRouteWithChildren;
   "/deployment/$deploymentId/_filterLayout/analytics": typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  "/deployment/$deploymentId/_filterLayout/edit": typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   "/deployment/$deploymentId/_filterLayout/info": typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   "/deployment/$deploymentId/_filterLayout/observations": typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   "/deployment/$deploymentId/_filterLayout/overview": typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -103,6 +113,7 @@ export interface FileRouteTypes {
     | "/deployment/$deploymentId/$"
     | "/deployment/$deploymentId"
     | "/deployment/$deploymentId/analytics"
+    | "/deployment/$deploymentId/edit"
     | "/deployment/$deploymentId/info"
     | "/deployment/$deploymentId/observations"
     | "/deployment/$deploymentId/overview"
@@ -112,6 +123,7 @@ export interface FileRouteTypes {
     | "/"
     | "/deployment/$deploymentId/$"
     | "/deployment/$deploymentId/analytics"
+    | "/deployment/$deploymentId/edit"
     | "/deployment/$deploymentId/info"
     | "/deployment/$deploymentId/observations"
     | "/deployment/$deploymentId/overview"
@@ -122,6 +134,7 @@ export interface FileRouteTypes {
     | "/deployment/$deploymentId/$"
     | "/deployment/$deploymentId/_filterLayout"
     | "/deployment/$deploymentId/_filterLayout/analytics"
+    | "/deployment/$deploymentId/_filterLayout/edit"
     | "/deployment/$deploymentId/_filterLayout/info"
     | "/deployment/$deploymentId/_filterLayout/observations"
     | "/deployment/$deploymentId/_filterLayout/overview"
@@ -185,6 +198,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof DeploymentDeploymentIdFilterLayoutInfoRouteImport;
       parentRoute: typeof DeploymentDeploymentIdFilterLayoutRoute;
     };
+    "/deployment/$deploymentId/_filterLayout/edit": {
+      id: "/deployment/$deploymentId/_filterLayout/edit";
+      path: "/edit";
+      fullPath: "/deployment/$deploymentId/edit";
+      preLoaderRoute: typeof DeploymentDeploymentIdFilterLayoutEditRouteImport;
+      parentRoute: typeof DeploymentDeploymentIdFilterLayoutRoute;
+    };
     "/deployment/$deploymentId/_filterLayout/analytics": {
       id: "/deployment/$deploymentId/_filterLayout/analytics";
       path: "/analytics";
@@ -197,6 +217,7 @@ declare module "@tanstack/react-router" {
 
 interface DeploymentDeploymentIdFilterLayoutRouteChildren {
   DeploymentDeploymentIdFilterLayoutAnalyticsRoute: typeof DeploymentDeploymentIdFilterLayoutAnalyticsRoute;
+  DeploymentDeploymentIdFilterLayoutEditRoute: typeof DeploymentDeploymentIdFilterLayoutEditRoute;
   DeploymentDeploymentIdFilterLayoutInfoRoute: typeof DeploymentDeploymentIdFilterLayoutInfoRoute;
   DeploymentDeploymentIdFilterLayoutObservationsRoute: typeof DeploymentDeploymentIdFilterLayoutObservationsRoute;
   DeploymentDeploymentIdFilterLayoutOverviewRoute: typeof DeploymentDeploymentIdFilterLayoutOverviewRoute;
@@ -207,6 +228,8 @@ const DeploymentDeploymentIdFilterLayoutRouteChildren: DeploymentDeploymentIdFil
   {
     DeploymentDeploymentIdFilterLayoutAnalyticsRoute:
       DeploymentDeploymentIdFilterLayoutAnalyticsRoute,
+    DeploymentDeploymentIdFilterLayoutEditRoute:
+      DeploymentDeploymentIdFilterLayoutEditRoute,
     DeploymentDeploymentIdFilterLayoutInfoRoute:
       DeploymentDeploymentIdFilterLayoutInfoRoute,
     DeploymentDeploymentIdFilterLayoutObservationsRoute:

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -52,7 +52,7 @@ function EditPage({
 }) {
   const schema = z
     .object({
-      name: z.string().min(1, "Name cannot be empty"),
+      name: z.string().optional(),
       description: z.string().optional(),
       startDate: z.iso.date().optional(),
       endDate: z.iso.date().nullable().optional(),

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -81,7 +81,16 @@ function EditPage({
 
   function handleDelete() {
     deleteDeployment.mutate(deploymentId, {
-      onSuccess: () => void navigate({ to: "/" }),
+      onSuccess: () => {
+        void navigate({ to: "/" });
+        toast.success("Deployment deleted successfully", { position: "top-center" });
+      },
+      onError: (error: Error) => {
+        toast.error("Failed to delete deployment", {
+          position: "top-center",
+          description: error.message,
+        });
+      },
     });
   }
 

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -50,22 +50,32 @@ function EditPage({
   deployment: Deployment;
   devices: DeploymentDevice[];
 }) {
-  const schema = z.object({
-    name: z.string(),
-    description: z.string().optional(),
-    startDate: z.iso.datetime(),
-    endDate: z.iso.datetime().nullable().optional(),
-    image: z.string().optional(),
-    devices: z.array(z.custom<DeploymentDevice>()).optional(),
-  });
+  const schema = z
+    .object({
+      name: z.string().min(1, "Name cannot be empty"),
+      description: z.string().optional(),
+      startDate: z.iso.date().optional(),
+      endDate: z.iso.date().nullable().optional(),
+      image: z.url().optional(),
+      devices: z.array(z.custom<DeploymentDevice>()).optional(),
+    })
+    .refine(
+      ({ startDate, endDate }) => {
+        if (!startDate || !endDate) {
+          return true;
+        }
+        return new Date(endDate) > new Date(startDate);
+      },
+      { message: "End date must come after start date", path: ["endDate"] },
+    );
 
   const { saveDeployment, isSaving } = useDeploymentMutations(deploymentId);
   const deleteDeployment = useDeleteDeployment();
   const navigate = useNavigate();
-  const [name, setName] = useState<string>();
+  const [name, setName] = useState<string | undefined>();
   const [description, setDescription] = useState<string | undefined>();
-  const [startDate, setStartDate] = useState<string>();
-  const [endDate, setEndDate] = useState<string | null>();
+  const [startDate, setStartDate] = useState<string | undefined>();
+  const [endDate, setEndDate] = useState<string | null | undefined>();
   const [image, setImage] = useState<string | undefined>();
   const [devices, setDevices] = useState<DeploymentDevice[] | undefined>();
 
@@ -85,40 +95,16 @@ function EditPage({
       devices,
     });
 
-    if (!result.success) {
+    if (result.success === false) {
       const errors = z.flattenError(result.error).fieldErrors;
-
-      if (errors.name) {
-        toast.warning(<p className="font-bold">Changes not made</p>, {
-          position: "top-center",
-          description: errors.name[0],
-        });
-        return;
-      }
-      if (errors.startDate) {
-        toast.warning(<p className="font-bold">Changes not made</p>, {
-          position: "top-center",
-          description: `Start date: ${errors.startDate[0]}`,
-        });
-        return;
-      }
-      if (errors.endDate) {
-        toast.warning(<p className="font-bold">Changes not made</p>, {
-          position: "top-center",
-          description: `End date: ${errors.endDate[0]}`,
-        });
-        return;
-      }
-      if (errors.devices) {
-        toast.warning(<p className="font-bold">Invalid devices</p>, {
-          position: "top-center",
-          description: errors.devices[0],
-        });
-        return;
-      }
-      toast.warning(<p className="font-bold">Validation failed</p>, {
+      const formatedErrors = Object.entries(errors).map(([key, value]) => (
+        <p key={key}>
+          {key} : {value}
+        </p>
+      ));
+      toast.warning(<p className="font-bold">Changes not made, check inputs:</p>, {
         position: "top-center",
-        description: "Please check your inputs.",
+        description: formatedErrors,
       });
       return;
     }

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -86,6 +86,20 @@ function EditPage({
   }
 
   function handleSave() {
+    const hasChanges =
+      name !== undefined ||
+      description !== undefined ||
+      startDate !== undefined ||
+      endDate !== undefined ||
+      image !== undefined ||
+      devices !== undefined;
+    if (!hasChanges) {
+      toast.warning(<p className="font-bold">Changes not made:</p>, {
+        position: "top-center",
+        description: "No changes found",
+      });
+      return;
+    }
     const result = schema.safeParse({
       name,
       description,
@@ -108,15 +122,26 @@ function EditPage({
       });
       return;
     }
-    saveDeployment({
-      name,
-      description,
-      startDate,
-      endDate,
-      image,
-      devices: devices ?? initialDevices,
-      initialDevices,
-    });
+    /*Undefined fields will be ignored in useDeploymentMutations hook.*/
+    saveDeployment(
+      {
+        name,
+        description,
+        startDate,
+        endDate,
+        image,
+        devices: devices ?? initialDevices,
+        initialDevices,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Deployment saved successfully", { position: "top-center" });
+        },
+        onError: () => {
+          toast.error("Failed to save deployment", { position: "top-center" });
+        },
+      },
+    );
   }
 
   return (

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -111,14 +111,14 @@ function EditPage({
 
     if (result.success === false) {
       const errors = z.flattenError(result.error).fieldErrors;
-      const formatedErrors = Object.entries(errors).map(([key, value]) => (
+      const formattedErrors = Object.entries(errors).map(([key, value]) => (
         <p key={key}>
           {key} : {value}
         </p>
       ));
       toast.warning(<p className="font-bold">Changes not made, check inputs:</p>, {
         position: "top-center",
-        description: formatedErrors,
+        description: formattedErrors,
       });
       return;
     }
@@ -135,10 +135,13 @@ function EditPage({
       },
       {
         onSuccess: () => {
-          toast.success("Deployment saved successfully", { position: "top-center" });
+          toast.success("Deployment updated successfully", { position: "top-center" });
         },
-        onError: () => {
-          toast.error("Failed to save deployment", { position: "top-center" });
+        onError: (error: Error) => {
+          toast.error("Failed to upload changes", {
+            position: "top-center",
+            description: error.message,
+          });
         },
       },
     );

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { toast } from "sonner";
+import { z } from "zod";
 
 import { EditDateRangeCard } from "@/components/deploymentEditor/EditDateRangeCard";
 import { EditDescriptionCard } from "@/components/deploymentEditor/EditDescriptionCard";
@@ -48,14 +50,22 @@ function EditPage({
   deployment: Deployment;
   devices: DeploymentDevice[];
 }) {
+  const schema = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    startDate: z.iso.datetime(),
+    endDate: z.iso.datetime().nullable().optional(),
+    image: z.string().optional(),
+    devices: z.array(z.custom<DeploymentDevice>()).optional(),
+  });
+
   const { saveDeployment, isSaving } = useDeploymentMutations(deploymentId);
   const deleteDeployment = useDeleteDeployment();
   const navigate = useNavigate();
-
-  const [name, setName] = useState<string | undefined>();
+  const [name, setName] = useState<string>();
   const [description, setDescription] = useState<string | undefined>();
-  const [startDate, setStartDate] = useState<string | undefined>();
-  const [endDate, setEndDate] = useState<string | null | undefined>();
+  const [startDate, setStartDate] = useState<string>();
+  const [endDate, setEndDate] = useState<string | null>();
   const [image, setImage] = useState<string | undefined>();
   const [devices, setDevices] = useState<DeploymentDevice[] | undefined>();
 
@@ -66,6 +76,52 @@ function EditPage({
   }
 
   function handleSave() {
+    const result = schema.safeParse({
+      name,
+      description,
+      startDate,
+      endDate,
+      image,
+      devices,
+    });
+
+    if (!result.success) {
+      const errors = z.flattenError(result.error).fieldErrors;
+
+      if (errors.name) {
+        toast.warning(<p className="font-bold">Changes not made</p>, {
+          position: "top-center",
+          description: errors.name[0],
+        });
+        return;
+      }
+      if (errors.startDate) {
+        toast.warning(<p className="font-bold">Changes not made</p>, {
+          position: "top-center",
+          description: `Start date: ${errors.startDate[0]}`,
+        });
+        return;
+      }
+      if (errors.endDate) {
+        toast.warning(<p className="font-bold">Changes not made</p>, {
+          position: "top-center",
+          description: `End date: ${errors.endDate[0]}`,
+        });
+        return;
+      }
+      if (errors.devices) {
+        toast.warning(<p className="font-bold">Invalid devices</p>, {
+          position: "top-center",
+          description: errors.devices[0],
+        });
+        return;
+      }
+      toast.warning(<p className="font-bold">Validation failed</p>, {
+        position: "top-center",
+        description: "Please check your inputs.",
+      });
+      return;
+    }
     saveDeployment({
       name,
       description,


### PR DESCRIPTION
closes #106
- Validates user input for create/edit deployment.
- Gives feedback to users with a toast popup.
- Error popup if server request fails, etc if device without name is asked for.
- Warning popups if input field is not accepted, informing user why input was not accepted.
- Success message if deployment edits were uploaded.
- Also some minor changes to dirty tracking for name field.