### PR TITLE
fix: handles invalid start date edit page

### DIFF
--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -195,7 +195,9 @@ function EditPage({
           <EditNameCard initialValue={deployment.name ?? ""} onChange={setName} />
           <EditDateRangeCard
             initialStartDate={
-              deployment.start_time ? deployment.start_time.toISOString().split("T")[0] : ""
+              !isNaN(deployment.start_time.getTime())
+                ? deployment.start_time.toISOString().split("T")[0]
+                : ""
             }
             initialEndDate={
               deployment.end_time ? deployment.end_time.toISOString().split("T")[0] : ""

--- a/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
+++ b/src/routes/deployment/$deploymentId/_filterLayout/edit.tsx
@@ -195,7 +195,7 @@ function EditPage({
           <EditNameCard initialValue={deployment.name ?? ""} onChange={setName} />
           <EditDateRangeCard
             initialStartDate={
-              !isNaN(deployment.start_time.getTime())
+              deployment.start_time && !isNaN(deployment.start_time.getTime())
                 ? deployment.start_time.toISOString().split("T")[0]
                 : ""
             }


### PR DESCRIPTION
Does not crash page if edit tries to load a deployment without start time.
Test with the deployment "invalid start time deployment test"